### PR TITLE
Taking Repository topics and merging them with tags.

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,15 +158,9 @@ With above config, when the crawler tries to fetch Dockerfile at the root of the
 
 - **Tagging a repo**
 
-It may happen that you want to "tag" some repos, to be able to filter easily on them when browsing the results. This is made possible by adding below config in the .githubCrawler file : 
-
-```yaml
-    tags:
-      - "someTag"
-      - "someOtherTag"
-```
-
-in output, this information will be attached to all the repositories for which it has been configured. 
+It may happen that you want to "tag" some repos, to be able to filter easily on them when browsing the results. 
+GitHub provides "topics" that are very easy to edit, which are actually similar to "tags".
+the tags information will be attached to all the repositories for which it has been configured. 
 
 ## Parsers
 

--- a/github-crawler-autoconfigure/src/test/resources/organisation.json
+++ b/github-crawler-autoconfigure/src/test/resources/organisation.json
@@ -83,6 +83,9 @@
     "forks_count": 2,
     "mirror_url": null,
     "open_issues_count": 0,
+    "topics": [
+      "testRepo"
+    ],
     "forks": 2,
     "open_issues": 0,
     "watchers": 0,
@@ -177,6 +180,9 @@
     "forks_count": 1,
     "mirror_url": null,
     "open_issues_count": 0,
+    "topics": [
+      "testRepo"
+    ],
     "forks": 1,
     "open_issues": 0,
     "watchers": 1,
@@ -271,6 +277,9 @@
     "forks_count": 39,
     "mirror_url": null,
     "open_issues_count": 3,
+    "topics": [
+      "testRepo"
+    ],
     "forks": 39,
     "open_issues": 3,
     "watchers": 2,
@@ -365,6 +374,9 @@
     "forks_count": 15,
     "mirror_url": null,
     "open_issues_count": 0,
+    "topics": [
+      "testRepo"
+    ],
     "forks": 15,
     "open_issues": 0,
     "watchers": 0,
@@ -459,6 +471,9 @@
     "forks_count": 27,
     "mirror_url": null,
     "open_issues_count": 2,
+    "topics": [
+      "testRepo"
+    ],
     "forks": 27,
     "open_issues": 2,
     "watchers": 0,
@@ -553,6 +568,9 @@
     "forks_count": 24,
     "mirror_url": null,
     "open_issues_count": 1,
+    "topics": [
+      "testRepo"
+    ],
     "forks": 24,
     "open_issues": 1,
     "watchers": 0,
@@ -647,6 +665,9 @@
     "forks_count": 0,
     "mirror_url": null,
     "open_issues_count": 0,
+    "topics": [
+      "testRepo"
+    ],
     "forks": 0,
     "open_issues": 0,
     "watchers": 0,

--- a/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/GitHubCrawler.kt
+++ b/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/GitHubCrawler.kt
@@ -114,7 +114,7 @@ class GitHubCrawler(private val remoteGitHub: RemoteGitHub,
                 .map { repo -> repo.flagAsExcludedIfConfiguredAtRepoLevel() }
                 .filter { repo -> shouldKeepForFurtherProcessing(repo, gitHubCrawlerProperties) }
                 .map{repo -> repo.copy(crawlerRunId= crawlerRunId)}
-                .map { repo -> repo.copyTagsFromRepoConfig() }
+                .map { repo -> repo.copyTagsFromRepoTopics() }
                 .map { repo -> repo.addGroups(environment.activeProfiles) }
                 .map { repo -> repositoryEnricher.identifyBranchesToParse(repo,gitHubCrawlerProperties.crawlAllBranches, organizationName!!) }
                 .map { repo -> repositoryEnricher.fetchIndicatorsValues(repo,gitHubCrawlerProperties) }

--- a/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/model/Repository.kt
+++ b/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/model/Repository.kt
@@ -42,7 +42,9 @@ data class Repository(val url: String,
                       @JsonIgnore
                       val searchResults: Map<String, String> = HashMap(),
                       @JsonIgnore
-                      var ownerTeam: String?
+                      var ownerTeam: String?,
+                      @JsonIgnore
+                      var topics: List<String> = emptyList()
 ) {
 
     val log = LoggerFactory.getLogger(this.javaClass)
@@ -99,13 +101,8 @@ data class Repository(val url: String,
 
     }
 
-    fun copyTagsFromRepoConfig(): Repository {
-
-        if (config != null) {
-            return this.copy(tags = config.tags)
-        } else {
-            return this
-        }
+    fun copyTagsFromRepoTopics(): Repository {
+        return this.copy(tags = this.topics)
     }
 
     fun fetchOwner(ownershipParser: OwnershipParser) : Repository {

--- a/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/output/HttpOutput.kt
+++ b/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/output/HttpOutput.kt
@@ -28,7 +28,8 @@ class HttpOutput(private val targetUrl: String) : GitHubCrawlerOutput {
                     analyzedRepository.groups,
                     analyzedRepository.crawlerRunId,
                     analyzedRepository.searchResults,
-                    analyzedRepository.ownerTeam ?: "Undefined")
+                    analyzedRepository.ownerTeam ?: "Undefined",
+                    analyzedRepository.topics)
 
             val response = restTemplate.postForEntity(targetUrl, output, String::class.java)
 

--- a/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/output/OutputIndicator.kt
+++ b/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/output/OutputIndicator.kt
@@ -15,7 +15,8 @@ data class OutputIndicator(val name: String,
                            val groups: List<String> = ArrayList(),
                            val crawlerRunId: String,
                            val searchResult:Map<String,String> = HashMap(),
-                           val ownerTeam: String) {
+                           val ownerTeam: String,
+                           val topics:List<String> = emptyList()) {
 
     val timestamp: String = ZonedDateTime.now().format(DateTimeFormatter.ISO_INSTANT)
 

--- a/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/remote/RemoteGitHubImpl.kt
+++ b/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/remote/RemoteGitHubImpl.kt
@@ -50,6 +50,7 @@ class RemoteGitHubImpl(val gitHubUrl: String) : RemoteGitHub {
         const val APPLICATION_JSON = "application/json"
         const val ACCEPT = "accept"
         const val CONFIG_VALIDATION_REQUEST_HEADER = "X-configValidationRequest"
+        const val APPLICATION_GITHUB_MERCY_PREVIEW_JSON = "application/vnd.github.mercy-preview+json"
     }
 
     private val internalGitHubClient: InternalGitHubClient = Feign.builder()
@@ -88,7 +89,7 @@ class RemoteGitHubImpl(val gitHubUrl: String) : RemoteGitHub {
 
         val requestBuilder = okhttp3.Request.Builder()
                 .url(reposUrl)
-                .header(ACCEPT, APPLICATION_JSON)
+                .header(ACCEPT, APPLICATION_GITHUB_MERCY_PREVIEW_JSON)
 
         if (isConfigCall) {
             requestBuilder.addHeader(CONFIG_VALIDATION_REQUEST_HEADER, "true")
@@ -130,7 +131,7 @@ class RemoteGitHubImpl(val gitHubUrl: String) : RemoteGitHub {
 
             val nextPageRequest = okhttp3.Request.Builder()
                     .url(nextPageLink)
-                    .header(ACCEPT, APPLICATION_JSON)
+                    .header(ACCEPT, APPLICATION_GITHUB_MERCY_PREVIEW_JSON)
                     .build()
 
             val nextPageResponse = httpClient.newCall(nextPageRequest).execute()

--- a/github-crawler-core/src/test/java/com/societegenerale/githubcrawler/output/FileOutputTest.kt
+++ b/github-crawler-core/src/test/java/com/societegenerale/githubcrawler/output/FileOutputTest.kt
@@ -70,10 +70,10 @@ class FileOutputTest{
         assertThat(lines[0]).startsWith("OUTPUT FOR GitHub crawler - ");
 
         assertThat(lines[1]).startsWith("Repository(url=http://hello, name=repo1, defaultBranch=master, creationDate=")
-        assertThat(lines[1]).contains(", excluded=false, config=null, reason=null, skipped=false, fullName=orgName/repoName1, indicators={}, branchesToParse=[], tags=[], groups=[], crawlerRunId=NO_CRAWLER_RUN_ID_DEFINED, searchResults={}, ownerTeam=null)")
+        assertThat(lines[1]).contains(", excluded=false, config=null, reason=null, skipped=false, fullName=orgName/repoName1, indicators={}, branchesToParse=[], tags=[], groups=[], crawlerRunId=NO_CRAWLER_RUN_ID_DEFINED, searchResults={}, ownerTeam=null, topics=[])")
 
         assertThat(lines[2]).startsWith("Repository(url=http://hello2, name=repo2, defaultBranch=master, creationDate=")
-        assertThat(lines[2]).endsWith(", excluded=false, config=null, reason=null, skipped=false, fullName=orgName/repoName2, indicators={}, branchesToParse=[], tags=[], groups=[], crawlerRunId=NO_CRAWLER_RUN_ID_DEFINED, searchResults={}, ownerTeam=null)")
+        assertThat(lines[2]).endsWith(", excluded=false, config=null, reason=null, skipped=false, fullName=orgName/repoName2, indicators={}, branchesToParse=[], tags=[], groups=[], crawlerRunId=NO_CRAWLER_RUN_ID_DEFINED, searchResults={}, ownerTeam=null, topics=[])")
 
 
 


### PR DESCRIPTION
## Summary
Fetching Github topics for the repository and merging them in tags as output

## Details

GitHub provides "topics" that are very easy to edit, which are similar to "tags" we should merge that concept, and take repo's topics (if any) and add them in the "tag" indicator that gets published in output

## Context
In any organization Repositories are categorized in various projects using topics( also known as Tags). This change make sure to provide the tags associated with each repository.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I've added tests for my code.
- [x] Documentation has been updated accordingly to this PR


## Related issue : 
https://github.com/societe-generale/github-crawler/issues/3