### PR TITLE
Using oauth for all requests, but providing token is not mandatory

### DIFF
--- a/github-crawler-autoconfigure/src/main/kotlin/com/societegenerale/githubcrawler/config/GitHubCrawlerAutoConfiguration.kt
+++ b/github-crawler-autoconfigure/src/main/kotlin/com/societegenerale/githubcrawler/config/GitHubCrawlerAutoConfiguration.kt
@@ -61,9 +61,11 @@ open class GitHubCrawlerAutoConfiguration {
 
 
     @Bean
-    open fun remoteGitHub(@Value("\${gitHub.url}") gitHubUrl: String,@Value("\${crawl.usersRepo.insteadOf.orgasRepos:false}" ) usersRepoInsteadOfOrgas: Boolean): RemoteGitHub {
+    open fun remoteGitHub(@Value("\${gitHub.url}") gitHubUrl: String,
+                          @Value("\${crawl.usersRepo.insteadOf.orgasRepos:false}" ) usersRepoInsteadOfOrgas: Boolean,
+                          @Value("\${gitHub.oauth.token}" ) oauthToken: String): RemoteGitHub {
 
-        return RemoteGitHubImpl(gitHubUrl,usersRepoInsteadOfOrgas)
+        return RemoteGitHubImpl(gitHubUrl,usersRepoInsteadOfOrgas,oauthToken)
     }
 
     @Bean

--- a/github-crawler-autoconfigure/src/test/java/com/societegenerale/githubcrawler/RemoteGitHubImplTest.kt
+++ b/github-crawler-autoconfigure/src/test/java/com/societegenerale/githubcrawler/RemoteGitHubImplTest.kt
@@ -34,14 +34,14 @@ class RemoteGitHubImplTest {
 
         }
 
-        val remoteGitHubForUser = RemoteGitHubImpl("http://localhost:9900/api/v3", true);
+        val remoteGitHubForUser = RemoteGitHubImpl("http://localhost:9900/api/v3", true,null);
         assertThat(gitHubMock.getNbHitsOnUserRepos()).isEqualTo(0);
         remoteGitHubForUser.validateRemoteConfig("someUser");
         assertThat(gitHubMock.getNbHitsOnUserRepos()).isEqualTo(1);
 
         gitHubMock.reset()
 
-        val remoteGitHubForOrg = RemoteGitHubImpl("http://localhost:9900/api/v3", false);
+        val remoteGitHubForOrg = RemoteGitHubImpl("http://localhost:9900/api/v3", false,null);
         remoteGitHubForOrg.validateRemoteConfig("MyOrganization");
         assertThat(gitHubMock.getNbHitsOnUserRepos()).isEqualTo(0);
     }

--- a/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/ownership/MembershipParser.kt
+++ b/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/ownership/MembershipParser.kt
@@ -5,7 +5,7 @@ import com.societegenerale.githubcrawler.remote.RemoteGitHub
 import org.slf4j.LoggerFactory
 import java.util.function.Consumer
 
-class MembershipParser(private val githubClient: RemoteGitHub, private val token: String, private val organizationName: String) {
+class MembershipParser(private val githubClient: RemoteGitHub, private val organizationName: String) {
 
     companion object {
         private val log = LoggerFactory.getLogger(MembershipParser::class.java)
@@ -15,15 +15,12 @@ class MembershipParser(private val githubClient: RemoteGitHub, private val token
 
     fun computeMembership(): Membership {
         val membership = Membership()
-        if (token.isBlank()) {
-            return membership
-        }
 
-        val teams = githubClient.fetchTeams(token, organizationName)
+        val teams = githubClient.fetchTeams(organizationName)
         log.debug("fetching teams for $organizationName organization returned $teams")
         teams.forEach(Consumer {
             if (EXCLUDED_TEAMS.contains(it.name).not()) {
-                val members = githubClient.fetchTeamsMembers(token, it.id)
+                val members = githubClient.fetchTeamsMembers(it.id)
                 membership.add(it, members)
                 log.debug("fetching teams members for ${it.name} team returned $members")
             }

--- a/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/remote/RemoteGitHub.kt
+++ b/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/remote/RemoteGitHub.kt
@@ -33,11 +33,9 @@ interface RemoteGitHub {
                     repositoryFullName: String,
                     commitSha: String): DetailedCommit
 
-    fun fetchTeams(token: String,
-                   organizationName: String): Set<Team>
+    fun fetchTeams(organizationName: String): Set<Team>
 
-    fun fetchTeamsMembers(token: String,
-                          teamId: String): Set<TeamMember>
+    fun fetchTeamsMembers(teamId: String): Set<TeamMember>
 
     fun fetchRepositories(organizationName: String): Set<Repository>
 

--- a/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/remote/RemoteGitHubImpl.kt
+++ b/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/remote/RemoteGitHubImpl.kt
@@ -94,6 +94,10 @@ class RemoteGitHubImpl @JvmOverloads constructor (val gitHubUrl: String, val use
 
         addOAuthTokenIfRequired(requestBuilder)
 
+        if (isConfigCall) {
+            requestBuilder.addHeader(CONFIG_VALIDATION_REQUEST_HEADER, "true")
+        }
+
         val request = requestBuilder.build()
 
         val response: Response
@@ -266,12 +270,12 @@ class RemoteGitHubImpl @JvmOverloads constructor (val gitHubUrl: String, val use
         return internalGitHubClient.fetchCommit(organizationName, repositoryFullName, commitSha)
     }
 
-    override fun fetchTeams(token: String, organizationName: String): Set<Team> {
-        return internalGitHubClient.fetchTeams(token, organizationName)
+    override fun fetchTeams(organizationName: String): Set<Team> {
+        return internalGitHubClient.fetchTeams(organizationName)
     }
 
-    override fun fetchTeamsMembers(token: String, teamId: String): Set<TeamMember> {
-        return internalGitHubClient.fetchTeamsMembers(token, teamId)
+    override fun fetchTeamsMembers(teamId: String): Set<TeamMember> {
+        return internalGitHubClient.fetchTeamsMembers(teamId)
     }
 
     override fun fetchRepoConfig(repoFullName: String, defaultBranch: String): RepositoryConfig {
@@ -338,12 +342,10 @@ private interface InternalGitHubClient {
                     @Param("commitSha") commitSha: String): DetailedCommit
 
     @RequestLine("GET /orgs/{organizationName}/teams")
-    fun fetchTeams(@Param("access_token") token: String,
-                   @Param("organizationName") organizationName: String): Set<Team>
+    fun fetchTeams(@Param("organizationName") organizationName: String): Set<Team>
 
     @RequestLine("GET /teams/{team}/members")
-    fun fetchTeamsMembers(@Param("access_token") token: String,
-                          @Param("team") teamId: String): Set<TeamMember>
+    fun fetchTeamsMembers(@Param("team") teamId: String): Set<TeamMember>
 
 
 }

--- a/github-crawler-core/src/main/resources/application.yml
+++ b/github-crawler-core/src/main/resources/application.yml
@@ -1,22 +1,20 @@
 gitHub:
   url: https://api.github.com
-  oauth.token: "1f81edb78cf51c5933c055531b95da7250da1cee"
+# token is mandatory in some cases, like when the rate limit is enabled and quota is much bigger for authenticated requests
+  oauth.token: "XXXXXXXXXXXXXXXXXXXXXXXXX"
 
 # or your GitHub Enterprise URL
 #gitHub.url: https://my-ghe-url/api/v3
 
+# default is false, ie we expect to parse orgs. Set it to true to parse a given user's repo
+#crawl.usersRepo.insteadOf.orgasRepos: true
 
 # your GitHub organization or user, for example myOrga in https://github.com/myOrga
-organizationName: joshlong
+organizationName: yourOrga
 
 publishExcludedRepositories: false
 
 crawlAllBranches: false
-
-crawl.usersRepo.insteadOf.orgasRepos: true
-
-output.ciDroidCsvReadyFile.indicatorsToOutput: "spring_boot_starter_parent_version"
-
 
 indicatorsToFetchByFile:
   "[pom.xml]":

--- a/github-crawler-core/src/main/resources/application.yml
+++ b/github-crawler-core/src/main/resources/application.yml
@@ -1,16 +1,26 @@
-gitHub.url: https://github.com
+gitHub:
+  url: https://api.github.com
+  oauth.token: "1f81edb78cf51c5933c055531b95da7250da1cee"
 
 # or your GitHub Enterprise URL
 #gitHub.url: https://my-ghe-url/api/v3
 
 
-# your GitHub organization, for example myOrga in https://github.com/myOrga
-organizationName: myOrga
+# your GitHub organization or user, for example myOrga in https://github.com/myOrga
+organizationName: joshlong
 
 publishExcludedRepositories: false
 
 crawlAllBranches: false
 
+crawl.usersRepo.insteadOf.orgasRepos: true
+
+output.ciDroidCsvReadyFile.indicatorsToOutput: "spring_boot_starter_parent_version"
 
 
-
+indicatorsToFetchByFile:
+  "[pom.xml]":
+  - name: spring_boot_starter_parent_version
+    method: findDependencyVersionInXml
+    params:
+      artifactId: spring-boot-starter-parent

--- a/github-crawler-core/src/test/java/com/societegenerale/githubcrawler/parsers/MembershipParserTest.kt
+++ b/github-crawler-core/src/test/java/com/societegenerale/githubcrawler/parsers/MembershipParserTest.kt
@@ -13,35 +13,33 @@ import org.mockito.Mockito.*
 class MembershipParserTest {
 
     companion object {
-        const val A_FAKE_TOKEN = "A_FAKE_TOKEN"
-
         const val ORGA_NAME = "A_SPECIFIC_ORGA"
     }
-    
+
     @Test
     fun should_build_membership() {
         //Given
         val githubClient: RemoteGitHub = mock(RemoteGitHub::class.java)
 
 
-        doReturn(setOf(Team("2", "Stark"),Team("3", "White Walkers")))
+        doReturn(setOf(Team("2", "Stark"), Team("3", "White Walkers")))
                 .`when`(githubClient)
-                .fetchTeams(A_FAKE_TOKEN, ORGA_NAME)
+                .fetchTeams(ORGA_NAME)
 
         doReturn(setOf(TeamMember("U1", "userFive"), TeamMember("U2", "userOne")))
                 .`when`(githubClient)
-                .fetchTeamsMembers(A_FAKE_TOKEN, "2")
+                .fetchTeamsMembers("2")
         doReturn(setOf(TeamMember("U3", "UserFour"), TeamMember("U4", "UserThree")))
                 .`when`(githubClient)
-                .fetchTeamsMembers(A_FAKE_TOKEN, "3")
+                .fetchTeamsMembers("3")
 
         //When
-        val membership = MembershipParser(githubClient, A_FAKE_TOKEN, ORGA_NAME).computeMembership()
+        val membership = MembershipParser(githubClient, ORGA_NAME).computeMembership()
 
         //Then
-        verify(githubClient).fetchTeams(A_FAKE_TOKEN, ORGA_NAME)
-        verify(githubClient).fetchTeamsMembers(A_FAKE_TOKEN, "2")
-        verify(githubClient).fetchTeamsMembers(A_FAKE_TOKEN, "3")
+        verify(githubClient).fetchTeams(ORGA_NAME)
+        verify(githubClient).fetchTeamsMembers("2")
+        verify(githubClient).fetchTeamsMembers("3")
 
         assertThat(membership).isNotNull()
         assertThat(membership.isEmpty()).isFalse()
@@ -53,14 +51,14 @@ class MembershipParserTest {
         val githubClient: RemoteGitHub = mock(RemoteGitHub::class.java)
         doReturn(setOf(Team("2", "Developers")))
                 .`when`(githubClient)
-                .fetchTeams(A_FAKE_TOKEN, ORGA_NAME)
+                .fetchTeams(ORGA_NAME)
 
         //When
-        MembershipParser(githubClient, A_FAKE_TOKEN, ORGA_NAME).computeMembership()
+        MembershipParser(githubClient, ORGA_NAME).computeMembership()
 
         //Then
-        verify(githubClient).fetchTeams(A_FAKE_TOKEN, ORGA_NAME)
-        verify(githubClient, never()).fetchTeamsMembers(ArgumentMatchers.anyString(), ArgumentMatchers.anyString())
+        verify(githubClient).fetchTeams(ORGA_NAME)
+        verify(githubClient, never()).fetchTeamsMembers(ArgumentMatchers.anyString())
     }
 
     @Test
@@ -69,48 +67,14 @@ class MembershipParserTest {
         val githubClient: RemoteGitHub = mock(RemoteGitHub::class.java)
         doReturn(setOf(Team("2", "Tech Leads")))
                 .`when`(githubClient)
-                .fetchTeams(A_FAKE_TOKEN, "FCC_OSD")
+                .fetchTeams("FCC_OSD")
 
         //When
-        MembershipParser(githubClient, A_FAKE_TOKEN, ORGA_NAME).computeMembership()
+        MembershipParser(githubClient, ORGA_NAME).computeMembership()
 
         //Then
-        verify(githubClient).fetchTeams(A_FAKE_TOKEN, ORGA_NAME)
-        verify(githubClient, never()).fetchTeamsMembers(ArgumentMatchers.anyString(), ArgumentMatchers.anyString())
-    }
-
-
-//  Do we keep this test or not ? token is not nullable
-//    @Test
-//    fun should_not_build_membership_if_no_token() {
-//        //Given
-//        val githubClient: RemoteGitHub = mock(RemoteGitHub::class.java)
-//        val organizationName = "FCC_OSD"
-//
-//        //When
-//        val membership = MembershipParser(githubClient,null, organizationName).computeMembership()
-//
-//        //Then
-//        verifyZeroInteractions(githubClient)
-//
-//        assertThat(membership).isNotNull()
-//        assertThat(membership.isEmpty()).isTrue()
-//    }
-
-    @Test
-    fun should_not_build_membership_if_blank_token() {
-        //Given
-        val githubClient: RemoteGitHub = mock(RemoteGitHub::class.java)
-
-
-        //When
-        val membership = MembershipParser(githubClient, "", ORGA_NAME).computeMembership()
-
-        //Then
-        verifyZeroInteractions(githubClient)
-
-        assertThat(membership).isNotNull()
-        assertThat(membership.isEmpty()).isTrue()
+        verify(githubClient).fetchTeams(ORGA_NAME)
+        verify(githubClient, never()).fetchTeamsMembers(ArgumentMatchers.anyString())
     }
 
 }


### PR DESCRIPTION
## Summary

When running Github crawler on github.com, you very quickly face a limitation : there's a very low rate-limit on non-authenticated requests to the API.

To be able to send several thousands calls to github.com API before being blocked, requests need to be authenticated.

Therefore, if we want to be able to get a meaningful report for repositories on github.com, all requests need to be authenticated, ideally through an OAuth token
