### PR TITLE
adding withTags property on CI-droid json output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- optional _withTags_ property on ciDroidJsonReadyFile output
 
 ### Changed
 - upgrade to Kotlin 1.3.0

--- a/github-crawler-autoconfigure/src/main/kotlin/com/societegenerale/githubcrawler/config/GitHubCrawlerOutputConfig.kt
+++ b/github-crawler-autoconfigure/src/main/kotlin/com/societegenerale/githubcrawler/config/GitHubCrawlerOutputConfig.kt
@@ -1,7 +1,5 @@
 package com.societegenerale.githubcrawler.config
 
-import com.societegenerale.githubcrawler.GitHubCrawlerProperties
-import com.societegenerale.githubcrawler.output.*
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.AutoConfigureOrder
@@ -51,9 +49,10 @@ open class GitHubCrawlerOutputConfig {
     @ConditionalOnProperty(name = ["output.ciDroidJsonReadyFile.indicatorsToOutput"])
     @AutoConfigureOrder(value = 4)
     @Throws(IOException::class)
-    open fun ciDroidReadyJsonFileOutput(@Value("\${output.ciDroidJsonReadyFile.indicatorsToOutput}") indicatorsToOutput: String): GitHubCrawlerOutput {
+    open fun ciDroidReadyJsonFileOutput(@Value("\${output.ciDroidJsonReadyFile.indicatorsToOutput}") indicatorsToOutput: String,
+                                        @Value("\${output.ciDroidJsonReadyFile.withTags}") withTags: Boolean=false): GitHubCrawlerOutput {
 
-        return CIdroidReadyJsonFileOutput(indicatorsToOutput.split(","))
+        return CIdroidReadyJsonFileOutput(indicatorsToOutput.split(","),withTags)
     }
 
 

--- a/github-crawler-autoconfigure/src/main/kotlin/com/societegenerale/githubcrawler/config/GitHubCrawlerOutputConfig.kt
+++ b/github-crawler-autoconfigure/src/main/kotlin/com/societegenerale/githubcrawler/config/GitHubCrawlerOutputConfig.kt
@@ -11,6 +11,9 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.web.client.RestTemplate
 import java.io.IOException
 
+import com.societegenerale.githubcrawler.GitHubCrawlerProperties
+import com.societegenerale.githubcrawler.output.*
+
 @Configuration
 @EnableConfigurationProperties(GitHubCrawlerProperties::class)
 open class GitHubCrawlerOutputConfig {

--- a/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/output/CIdroidReadyJsonFileOutput.kt
+++ b/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/output/CIdroidReadyJsonFileOutput.kt
@@ -16,7 +16,7 @@ import java.util.*
 
 class CIdroidReadyJsonFileOutput @Throws(IOException::class)
 
-constructor(val indicatorsToOutput: List<String>) : GitHubCrawlerOutput {
+constructor(val indicatorsToOutput: List<String>, val withTags: Boolean=false) : GitHubCrawlerOutput {
 
     val log = LoggerFactory.getLogger(this.javaClass)
 
@@ -52,6 +52,10 @@ constructor(val indicatorsToOutput: List<String>) : GitHubCrawlerOutput {
                 sb.append("\"filePathOnRepo\": \"").append(actualIndicators.get(indicatorsToOutput[0])).append("\",")
 
                 appendOtherIndicatorsIfAny(sb, actualIndicators)
+
+                if(withTags){
+                    sb.append("\"tags\": \"").append(analyzedRepository.tags).append("\",")
+                }
 
                 sb.append("\"branchName\": \"").append(branch.name).append("\"")
 


### PR DESCRIPTION
## Summary

adding the possibility to output the repos tags (ie topics), along with the indicators, to enable easy sorting, if an action has to be performed on all repositories with a given tag. 

## Details

added a _withTags_ property under output.ciDroidJsonReadyFile - default is false. 
