### PR TITLE
autocompletion for properties in IDE

### DIFF
--- a/github-crawler-autoconfigure/src/test/java/com/societegenerale/githubcrawler/GitHubCrawlerIT.java
+++ b/github-crawler-autoconfigure/src/test/java/com/societegenerale/githubcrawler/GitHubCrawlerIT.java
@@ -4,7 +4,6 @@ import com.societegenerale.githubcrawler.config.GitHubCrawlerAutoConfiguration;
 import com.societegenerale.githubcrawler.config.TestConfig;
 import com.societegenerale.githubcrawler.mocks.GitHubMock;
 import com.societegenerale.githubcrawler.model.Repository;
-import lombok.val;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -230,7 +229,7 @@ public class GitHubCrawlerIT {
 
 		String indicatorName = "docker_image_used";
 
-		val indicatorValueFoundInFilePostRedirection = processedRepositories.stream().filter(repo -> repo.getName().equals(repoWithConfig))
+		Optional<String> indicatorValueFoundInFilePostRedirection = processedRepositories.stream().filter(repo -> repo.getName().equals(repoWithConfig))
 				.map(repo -> repo.getIndicatorsForBranch("master"))
 				.filter(indicators -> indicators.containsKey(indicatorName))
 				.map(indicators -> indicators.get(indicatorName))

--- a/github-crawler-autoconfigure/src/test/java/com/societegenerale/githubcrawler/config/TestConfig.java
+++ b/github-crawler-autoconfigure/src/test/java/com/societegenerale/githubcrawler/config/TestConfig.java
@@ -8,8 +8,6 @@ import com.societegenerale.githubcrawler.ownership.NoOpOwnershipParser;
 import com.societegenerale.githubcrawler.ownership.OwnershipParser;
 import com.societegenerale.githubcrawler.parsers.FileContentParser;
 import com.societegenerale.githubcrawler.remote.RemoteGitHub;
-import lombok.Getter;
-import lombok.val;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -42,7 +40,7 @@ public class TestConfig {
             ConfigValidator configValidator,
             List<FileContentParser> fileContentParsers) {
 
-        val repositoryEnricher = new RepositoryEnricher(remoteGitHub);
+        RepositoryEnricher repositoryEnricher = new RepositoryEnricher(remoteGitHub);
 
         return new GitHubCrawler(remoteGitHub, ownershipParser, output, repositoryEnricher, gitHubCrawlerProperties, environment,organizationName,gitHubUrl,configValidator,fileContentParsers);
     }
@@ -69,8 +67,11 @@ public class TestConfig {
 
     public class InMemoryGitHubCrawlerOutput implements GitHubCrawlerOutput {
 
-        @Getter
         private Map<String, Repository> analyzedRepositories = new HashMap<>();
+
+        public Map<String, Repository> getAnalyzedRepositories() {
+            return analyzedRepositories;
+        }
 
         @Override
         public void output(Repository analyzedRepository) throws IOException {

--- a/github-crawler-autoconfigure/src/test/java/com/societegenerale/githubcrawler/mocks/GitHubMock.java
+++ b/github-crawler-autoconfigure/src/test/java/com/societegenerale/githubcrawler/mocks/GitHubMock.java
@@ -1,8 +1,5 @@
 package com.societegenerale.githubcrawler.mocks;
 
-import lombok.Getter;
-import lombok.Setter;
-import lombok.extern.slf4j.Slf4j;
 import net.codestory.http.Context;
 import net.codestory.http.WebServer;
 import net.codestory.http.constants.HttpStatus;
@@ -11,6 +8,7 @@ import net.codestory.http.errors.NotFoundException;
 import net.codestory.http.payload.Payload;
 import org.apache.commons.io.FileUtils;
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.stereotype.Component;
@@ -26,8 +24,9 @@ import java.util.*;
 import static com.societegenerale.githubcrawler.remote.RemoteGitHubImpl.CONFIG_VALIDATION_REQUEST_HEADER;
 
 @Component
-@Slf4j
 public class GitHubMock implements RemoteServiceMock {
+
+    private static final Logger log = org.slf4j.LoggerFactory.getLogger(GitHubMock.class);
 
     private String organisationResponse = "organisation.json";
 
@@ -39,28 +38,39 @@ public class GitHubMock implements RemoteServiceMock {
 
     private Map<String, String> existingResources = new HashMap<>();
 
-    @Getter
+    public List<String> getRepoConfigHits() {
+        return repoConfigHits;
+    }
+
+    public List<String> getPomXmlHits() {
+        return pomXmlHits;
+    }
+
+    public int getNbPages() {
+        return nbPages;
+    }
+
+    public boolean isHasCalledNextPage() {
+        return hasCalledNextPage;
+    }
+
     private List<String> repoConfigHits = new ArrayList<>();
 
-    @Getter
     private List<String> pomXmlHits = new ArrayList<>();
 
-    @Setter
-    @Getter
     private int nbPages = 1;
 
     private int nbHitsOnUserRepos = 0;
 
     private int currentPage = 1;
 
-    @Getter
+
     private boolean hasCalledNextPage = false;
 
     private List<String> reposWithNoConfig = new ArrayList<>();
 
     private List<String> reposWithPomXml = new ArrayList<>();
 
-    @Getter
     private int searchHitsCount = 0;
 
     private boolean shouldReturnError409OnFetchCommits = false;
@@ -401,6 +411,14 @@ public class GitHubMock implements RemoteServiceMock {
 
     public void setReturnError409OnFetchCommits(boolean shouldReturnError) {
         this.shouldReturnError409OnFetchCommits=shouldReturnError;
+    }
+
+    public void setNbPages(int nbPages) {
+        this.nbPages=nbPages;
+    }
+
+    public int getSearchHitsCount() {
+        return searchHitsCount;
     }
 
     private class ConflictException extends HttpException {

--- a/github-crawler-core/pom.xml
+++ b/github-crawler-core/pom.xml
@@ -96,6 +96,48 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
     </dependencies>
+
+    <build>
+
+        <plugins>
+            <plugin>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <version>${kotlin.version}</version>
+
+                <executions>
+                    <execution>
+                        <id>kapt</id>
+                        <goals>
+                            <goal>kapt</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>src/main/kotlin</sourceDir>
+                            </sourceDirs>
+
+                            <annotationProcessorPaths>
+
+
+                                <!-- Specify your annotation processors here. -->
+                                <annotationProcessorPath>
+                                    <groupId>com.google.dagger</groupId>
+                                    <artifactId>dagger-compiler</artifactId>
+                                    <version>2.9</version>
+                                </annotationProcessorPath>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/GitHubCrawlerProperties.kt
+++ b/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/GitHubCrawlerProperties.kt
@@ -1,9 +1,11 @@
 package com.societegenerale.githubcrawler
 
 import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 
 
 @ConfigurationProperties
+@EnableConfigurationProperties
 class GitHubCrawlerProperties(val searchesPerRepo: Map<String, SearchParam> = HashMap(),
                               val indicatorsToFetchByFile: Map<com.societegenerale.githubcrawler.FileToParse, List<IndicatorDefinition>> = HashMap(),
                               var repositoriesToExclude: List<String> = ArrayList(),

--- a/github-crawler-core/src/test/java/com/societegenerale/githubcrawler/ConfigParserTest.java
+++ b/github-crawler-core/src/test/java/com/societegenerale/githubcrawler/ConfigParserTest.java
@@ -3,7 +3,7 @@ package com.societegenerale.githubcrawler;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.module.kotlin.KotlinModule;
-import lombok.val;
+
 import org.junit.Test;
 import org.springframework.util.StreamUtils;
 
@@ -16,12 +16,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class ConfigParserTest {
 
+    ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+
     @Test
     public void canParseSimpleYamlConfig() throws IOException {
 
         String configToParse = "excluded: true";
-
-        val mapper = new ObjectMapper(new YAMLFactory());
 
         RepositoryConfig parsedRepositoryConfig = mapper.readValue(configToParse, RepositoryConfig.class);
 
@@ -34,8 +34,6 @@ public class ConfigParserTest {
         InputStream is = getClass().getClassLoader().getResourceAsStream("sampleRepoConfig.yaml");
         String configToParse = StreamUtils.copyToString(is, Charset.forName("UTF-8"));
 
-        val mapper = new ObjectMapper(new YAMLFactory());
-
         mapper.registerModule(new KotlinModule());
 
         RepositoryConfig parsedRepositoryConfig = mapper.readValue(configToParse, RepositoryConfig.class);
@@ -44,7 +42,7 @@ public class ConfigParserTest {
         assertThat(parsedRepositoryConfig.getExcluded()).isFalse();
         assertThat(parsedRepositoryConfig.getFilesToParse()).hasSize(1);
 
-        val firstFile = parsedRepositoryConfig.getFilesToParse().get(0);
+        FileToParse firstFile = parsedRepositoryConfig.getFilesToParse().get(0);
         assertThat(firstFile.getRedirectTo()).isEqualTo("moduleWhereDockerFileIs/Dockerfile");
         assertThat(firstFile.getName()).isEqualTo("Dockerfile");
     }
@@ -54,7 +52,7 @@ public class ConfigParserTest {
 
         String configToParse = "{\"excluded\": true}";
 
-        val mapper = new ObjectMapper();
+        ObjectMapper mapper = new ObjectMapper();
 
         RepositoryConfig parsedRepositoryConfig = mapper.readValue(configToParse, RepositoryConfig.class);
 

--- a/pom.xml
+++ b/pom.xml
@@ -100,11 +100,6 @@
             <version>26.0-jre</version>
         </dependency>
 
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <optional>true</optional>
-        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Fixes #53 

removing Lombok to allow the use of Kapt as an annotation processor (compilation issues when we have both Lombok and Kapt annotation processors)
