### PR TITLE
removing Component annotation from parsers

### DIFF
--- a/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/parsers/CountXmlElementsParser.kt
+++ b/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/parsers/CountXmlElementsParser.kt
@@ -4,11 +4,9 @@ import com.societegenerale.githubcrawler.IndicatorDefinition
 import org.dom4j.Document
 import org.dom4j.io.SAXReader
 import org.slf4j.LoggerFactory
-import org.springframework.stereotype.Component
 import org.xml.sax.InputSource
 import java.io.StringReader
 
-@Component
 class CountXmlElementsParser : FileContentParser {
 
     companion object {

--- a/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/parsers/FirstMatchingRegexpParser.kt
+++ b/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/parsers/FirstMatchingRegexpParser.kt
@@ -2,11 +2,10 @@ package com.societegenerale.githubcrawler.parsers
 
 import com.societegenerale.githubcrawler.IndicatorDefinition
 import org.slf4j.LoggerFactory
-import org.springframework.stereotype.Component
 import java.util.*
 import java.util.regex.Pattern
 
-@Component
+
 class FirstMatchingRegexpParser : FileContentParser {
 
     companion object {

--- a/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/parsers/PomXmlParserForDependencyVersion.kt
+++ b/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/parsers/PomXmlParserForDependencyVersion.kt
@@ -2,7 +2,6 @@ package com.societegenerale.githubcrawler.parsers
 
 import com.societegenerale.githubcrawler.IndicatorDefinition
 import org.slf4j.LoggerFactory
-import org.springframework.stereotype.Component
 import org.xml.sax.Attributes
 import org.xml.sax.InputSource
 import org.xml.sax.SAXException
@@ -12,7 +11,7 @@ import java.io.StringReader
 import java.util.*
 import javax.xml.parsers.SAXParserFactory
 
-@Component
+
 class PomXmlParserForDependencyVersion : FileContentParser {
 
     companion object {

--- a/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/parsers/SimpleFilePathParser.kt
+++ b/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/parsers/SimpleFilePathParser.kt
@@ -2,10 +2,8 @@ package com.societegenerale.githubcrawler.parsers
 
 import com.societegenerale.githubcrawler.IndicatorDefinition
 import org.slf4j.LoggerFactory
-import org.springframework.stereotype.Component
 import java.util.*
 
-@Component
 
 /**
  * This parser is a bit special - it ignores the file content, and just returns the file path as an indicator value.

--- a/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/parsers/YamlParserForPropertyValue.kt
+++ b/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/parsers/YamlParserForPropertyValue.kt
@@ -2,11 +2,9 @@ package com.societegenerale.githubcrawler.parsers
 
 import com.societegenerale.githubcrawler.IndicatorDefinition
 import org.slf4j.LoggerFactory
-import org.springframework.stereotype.Component
 import org.yaml.snakeyaml.Yaml
 import org.yaml.snakeyaml.scanner.ScannerException
 
-@Component
 class YamlParserForPropertyValue : FileContentParser {
 
     companion object {


### PR DESCRIPTION
removing Component annotation from parsers, so that we have full control of beans being instantiated in config classes