### PR TITLE
fix crash when fetching commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Fixed
 - Kotlin compiler warnings
+- issue #41 - fetching commits on a repo was failing
 
 
 ## [1.0.11] - 2018-10-26

--- a/github-crawler-autoconfigure/src/test/java/com/societegenerale/githubcrawler/RemoteGitHubImplLiveTest.kt
+++ b/github-crawler-autoconfigure/src/test/java/com/societegenerale/githubcrawler/RemoteGitHubImplLiveTest.kt
@@ -25,7 +25,7 @@ class RemoteGitHubImplLiveTest {
 
         val remoteGitHubForUser = RemoteGitHubImpl("https://api.github.com", false,null);
 
-        val commits=remoteGitHubForUser.fetchCommits("myOrga","myRepo",150)
+        val commits=remoteGitHubForUser.fetchCommits("myOrga/myRepo",150)
 
         assertThat(commits).isEmpty()
     }

--- a/github-crawler-autoconfigure/src/test/java/com/societegenerale/githubcrawler/RemoteGitHubImplTest.kt
+++ b/github-crawler-autoconfigure/src/test/java/com/societegenerale/githubcrawler/RemoteGitHubImplTest.kt
@@ -67,7 +67,7 @@ class RemoteGitHubImplTest {
         val remoteGitHubForUser = RemoteGitHubImpl("http://localhost:9900/api/v3", true, null);
         githubMockServer.setReturnError409OnFetchCommits(true)
 
-        var commits=remoteGitHubForUser.fetchCommits("MyOrganization","myRepo",150)
+        var commits=remoteGitHubForUser.fetchCommits("MyOrganization/myRepo",150)
 
         assertThat(commits.isEmpty())
     }

--- a/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/remote/RemoteGitHub.kt
+++ b/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/remote/RemoteGitHub.kt
@@ -24,12 +24,10 @@ interface RemoteGitHub {
     @Throws(NoFileFoundException::class)
     fun fetchFileContent(repositoryFullName: String, branchName: String, fileToFetch: String): String
 
-    fun fetchCommits(organizationName: String,
-                     repositoryFullName: String,
+    fun fetchCommits(repositoryFullName: String,
                      perPage: Int): Set<Commit>
 
-    fun fetchCommit(organizationName: String,
-                    repositoryFullName: String,
+    fun fetchCommit(repositoryFullName: String,
                     commitSha: String): DetailedCommit
 
     fun fetchTeams(organizationName: String): Set<Team>

--- a/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/remote/RemoteGitHubImpl.kt
+++ b/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/remote/RemoteGitHubImpl.kt
@@ -275,10 +275,10 @@ class RemoteGitHubImpl @JvmOverloads constructor(val gitHubUrl: String, val user
 
     }
 
-    override fun fetchCommits(organizationName: String, repositoryFullName: String, perPage: Int): Set<Commit> {
+    override fun fetchCommits(repositoryFullName: String, perPage: Int): Set<Commit> {
 
         return try {
-                internalGitHubClient.fetchCommits(organizationName, repositoryFullName, perPage)
+                internalGitHubClient.fetchCommits(repositoryFullName, perPage)
             }
             catch (e: GitHubResponseDecoder.GithubException) {
                 log.warn("not able to fetch commits for repo $repositoryFullName",e)
@@ -287,8 +287,8 @@ class RemoteGitHubImpl @JvmOverloads constructor(val gitHubUrl: String, val user
 
     }
 
-    override fun fetchCommit(organizationName: String, repositoryFullName: String, commitSha: String): DetailedCommit {
-        return internalGitHubClient.fetchCommit(organizationName, repositoryFullName, commitSha)
+    override fun fetchCommit(repositoryFullName: String, commitSha: String): DetailedCommit {
+        return internalGitHubClient.fetchCommit(repositoryFullName, commitSha)
     }
 
     override fun fetchTeams(organizationName: String): Set<Team> {
@@ -351,15 +351,13 @@ private interface InternalGitHubClient {
                         @Param("branchName") branchName: String,
                         @Param("fileToFetch") fileToFetch: String): FileOnRepository
 
-    @RequestLine("GET /repos/{organizationName}/{repositoryFullName}/commits")
-    fun fetchCommits(@Param("organizationName") organizationName: String,
-                     @Param("repositoryFullName") repositoryFullName: String,
+    @RequestLine("GET /repos/{repositoryFullName}/commits")
+    fun fetchCommits(@Param("repositoryFullName") repositoryFullName: String,
                      @Param("per_page") perPage: Int): Set<Commit>
 
 
-    @RequestLine("GET /repos/{organizationName}/{repositoryFullName}/commits/{commitSha}")
-    fun fetchCommit(@Param("organizationName") organizationName: String,
-                    @Param("repositoryFullName") repositoryFullName: String,
+    @RequestLine("GET /repos/{repositoryFullName}/commits/{commitSha}")
+    fun fetchCommit(@Param("repositoryFullName") repositoryFullName: String,
                     @Param("commitSha") commitSha: String): DetailedCommit
 
     @RequestLine("GET /orgs/{organizationName}/teams")
@@ -411,7 +409,7 @@ internal class GitHubResponseDecoder : Decoder {
             if (type.typeName == FileOnRepository::class.java.name) {
                 throw NoFileFoundFeignException("no file found on repository")
             } else {
-                throw NoFileFoundFeignException("problem while fetching content, of unknown type")
+                throw NoFileFoundFeignException("problem while fetching content, of unknown type ${type.typeName}")
             }
         }
         else {

--- a/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/repoTaskToPerform/ownership/OwnershipParserImpl.kt
+++ b/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/repoTaskToPerform/ownership/OwnershipParserImpl.kt
@@ -38,8 +38,8 @@ class OwnershipParserImpl(private val githubClient: RemoteGitHub, private val me
             return UNDEFINED
         }
 
-        val commits = githubClient.fetchCommits(organizationName, repositoryFullName, lastCommitNumber)
-        val commitsWithStats = commits.map { (sha) -> githubClient.fetchCommit(organizationName, repositoryFullName, sha) }
+        val commits = githubClient.fetchCommits(repositoryFullName, lastCommitNumber)
+        val commitsWithStats = commits.map { (sha) -> githubClient.fetchCommit(repositoryFullName, sha) }
         log.debug("${commitsWithStats.size} fetched for $organizationName and $repositoryFullName (with max fetch to $lastCommitNumber)")
         return commitsWithStats
                 .filter { it.author != null }

--- a/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/repoTaskToPerform/ownership/RepoOwnershipComputer.kt
+++ b/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/repoTaskToPerform/ownership/RepoOwnershipComputer.kt
@@ -45,8 +45,8 @@ class RepoOwnershipComputer(private val githubClient: RemoteGitHub,
             return hashMapOf(Pair(Branch(repository.defaultBranch), hashMapOf(Pair(INDICATOR_NAME, UNDEFINED))))
         }
 
-        val commits = githubClient.fetchCommits(organizationName, repository.fullName, lastCommitNumber)
-        val commitsWithStats = commits.map { (sha) -> githubClient.fetchCommit(organizationName, repository.fullName, sha) }
+        val commits = githubClient.fetchCommits(repository.fullName, lastCommitNumber)
+        val commitsWithStats = commits.map { (sha) -> githubClient.fetchCommit(repository.fullName, sha) }
         log.debug("${commitsWithStats.size} fetched for $organizationName and $repository.fullName (with max fetch to $lastCommitNumber)")
         val owner = commitsWithStats
                 .filter { it.author != null }

--- a/github-crawler-core/src/test/java/com/societegenerale/githubcrawler/parsers/OwnershipParserImplTest.kt
+++ b/github-crawler-core/src/test/java/com/societegenerale/githubcrawler/parsers/OwnershipParserImplTest.kt
@@ -35,23 +35,23 @@ class OwnershipParserImplTest {
 
         doReturn(setOf(Commit("1"), Commit("2"), Commit("3")))
                 .`when`(githubClient)
-                .fetchCommits(organizationName, repositoryFullName, lastCommitNumber)
+                .fetchCommits(repositoryFullName, lastCommitNumber)
 
         doReturn(DetailedCommit("1", Author("12", "userFive"), CommitStats(500)))
                 .`when`(githubClient)
-                .fetchCommit(organizationName, repositoryFullName, "1")
+                .fetchCommit(repositoryFullName, "1")
         doReturn(DetailedCommit("2", Author("13", "UserFour"), CommitStats(450)))
                 .`when`(githubClient)
-                .fetchCommit(organizationName, repositoryFullName, "2")
+                .fetchCommit(repositoryFullName, "2")
         doReturn(DetailedCommit("3", Author("14", "UserThree"), CommitStats(49)))
                 .`when`(githubClient)
-                .fetchCommit(organizationName, repositoryFullName, "3")
+                .fetchCommit(repositoryFullName, "3")
 
         //When
         val teamOwner: String = OwnershipParserImpl(githubClient, membershipParser, organizationName).computeOwnershipFor( repositoryFullName, lastCommitNumber)
 
         //Then
-        verify(githubClient).fetchCommits(organizationName, repositoryFullName, lastCommitNumber)
+        verify(githubClient).fetchCommits(repositoryFullName, lastCommitNumber)
         assertThat(teamOwner).isEqualTo("Stark")
     }
 


### PR DESCRIPTION
fixes #41 

URL used to fetch commits was incorrect - repo full name is enough, no need for organization name
