### PR TITLE
Allowing date patterns in target url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- possibility to configure targetUrl with a date pattern (useful when POSTing to ElasticSearch)
 
 ### Changed
 

--- a/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/output/HttpOutput.kt
+++ b/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/output/HttpOutput.kt
@@ -5,15 +5,21 @@ import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.web.client.HttpClientErrorException
 import org.springframework.web.client.RestTemplate
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 
 
 /**
  * This output will make a POST to the configured targetUrl, using the analyzed repository as a payload. If the analyzed repository has indicators for X branches, we'll post the indicators for each branch individually (so X times)
+ *
  */
-class HttpOutput(private val targetUrl: String,
-                 private val restTemplate: RestTemplate) : GitHubCrawlerOutput {
+class HttpOutput(targetUrl: String,
+                 private val restTemplate: RestTemplate,
+                 private val currentLocalDate: LocalDate=LocalDate.now()) : GitHubCrawlerOutput {
 
     val log = LoggerFactory.getLogger(this.javaClass)
+
+    private var internalTargetUrl = buildUrlAccordingToPlaceholderIfRequired(targetUrl)
 
     override fun output(analyzedRepository: Repository) {
 
@@ -32,7 +38,7 @@ class HttpOutput(private val targetUrl: String,
             val response : ResponseEntity<String>
 
             try {
-                response = restTemplate.postForEntity(targetUrl, output, String::class.java)
+                response = restTemplate.postForEntity(internalTargetUrl, output, String::class.java)
 
                 if (!response.statusCode.is2xxSuccessful) {
                     logHttpError(analyzedRepository.name, response.statusCodeValue,response.body)
@@ -45,6 +51,33 @@ class HttpOutput(private val targetUrl: String,
 
     private fun logHttpError(repoName: String, errorCode : Int, message : String?) {
         log.warn("couldn't push result for repo {} - code {} - {}", repoName, errorCode, message)
+    }
+
+    /**
+     * It's useful to be able to configure a targetURL with a date pattern, to push to an ElasticSearch index, for example http://myElasticSearch/{yyyy-MM}
+     *
+     * Since the "real" targetUrl is computed once at the beginning, if the crawler runs for too long it will send  data to an index that is "older" than the current time.
+     * For example, if the crawler is configured to send data to http://myElasticSearch/{yyyy-MM-dd}, is launched at 11:58pm and runs for 5min, after midnight data will still be sent to D-1 index.
+     *
+     */
+    private fun buildUrlAccordingToPlaceholderIfRequired(targetUrlFromProperties: String): String{
+
+        return if(containsPlaceHolders(targetUrlFromProperties)){
+
+            val patternToReplace=Regex(".*\\{(.*)}.*").find(targetUrlFromProperties)!!.groupValues[1]
+
+            val valueForPlaceHolder=currentLocalDate.format(DateTimeFormatter.ofPattern(patternToReplace))
+
+            return targetUrlFromProperties.replace("{$patternToReplace}",valueForPlaceHolder)
+        }
+        else{
+            targetUrlFromProperties
+        }
+
+    }
+
+    private fun containsPlaceHolders(targetUrlFromProperties: String): Boolean {
+        return targetUrlFromProperties.matches(Regex(".*\\{.*}.*"))
     }
 
 }

--- a/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/output/HttpOutput.kt
+++ b/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/output/HttpOutput.kt
@@ -64,6 +64,7 @@ class HttpOutput(targetUrl: String,
 
         return if(containsPlaceHolders(targetUrlFromProperties)){
 
+            //if pattern is not found, this will fail, which is OK - stacktrace will explain the error.
             val patternToReplace=Regex(".*\\{(.*)}.*").find(targetUrlFromProperties)!!.groupValues[1]
 
             val valueForPlaceHolder=currentLocalDate.format(DateTimeFormatter.ofPattern(patternToReplace))


### PR DESCRIPTION
## Summary

When posting results to ElasticSearch, it can be useful to POST on a time-based index. 

--> Giving the possibility to configure the targetUrl with a placeholder for the date (using Java date format), so that targetUrl is computed once when the crawler is launched, based on today's date