### PR TITLE
Explicit scm declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ Below configuration shows how outputs, indicators and actions are configured und
 github-crawler:
     
     githubConfig:    
+        # since v1.3.0, we need to mention the source control type. defaults to GitHub, but other options are possible
+        # as defined in https://github.com/societe-generale/github-crawler/blob/master/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/GithubConfig.kt
+        type: "GITHUB"
         # the base GitHub URL for your Github enterprise instance to crawl
         # or if it's github.com...
         # gitHub.url: https://api.github.com
@@ -187,9 +190,12 @@ From v1.2.0 onward, basic support for gitLab is available ! It all boils down to
 - run the application with proper Spring Boot profile, ie with ```-Dspring.profiles.active=gitLab``` on the command line
 - Since the crawler is still primarily for GitHub, the config properties haven't been adapted (yet ?) for Gitlab. So your config would look like : 
 
+note : if you're using v1.3.0+ , then we won't use profiles anymore, but use the `github-crawler.githubConfig.type` property and set it to `GITLAB` . 
+
 ```
     github-crawler:
       githubConfig:
+        type: "GITLAB"
         apiUrl: https://gitlab.com/api/v4/
 
         # your Gitlab personal access token

--- a/github-crawler-autoconfigure/pom.xml
+++ b/github-crawler-autoconfigure/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.societegenerale.github-crawler</groupId>
     <artifactId>github-crawler-autoconfigure</artifactId>
-    <version>1.2.2-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>github-crawler-autoconfigure</name>
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.societegenerale.github-crawler</groupId>
         <artifactId>github-crawler-parent</artifactId>
-        <version>1.2.2-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/github-crawler-autoconfigure/src/main/kotlin/com/societegenerale/githubcrawler/config/GitHubConfiguration.kt
+++ b/github-crawler-autoconfigure/src/main/kotlin/com/societegenerale/githubcrawler/config/GitHubConfiguration.kt
@@ -4,12 +4,12 @@ package com.societegenerale.githubcrawler.config
 import com.societegenerale.githubcrawler.GitHubCrawlerProperties
 import com.societegenerale.githubcrawler.remote.RemoteGitHub
 import com.societegenerale.githubcrawler.remote.RemoteGitHubImpl
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.context.annotation.Profile
 
 @Configuration
-@Profile("!gitLab")
+@ConditionalOnProperty(prefix = "github-crawler.githubConfig", name = ["type"], havingValue = "GITHUB")
 open class GitHubConfiguration {
 
     @Bean

--- a/github-crawler-autoconfigure/src/main/kotlin/com/societegenerale/githubcrawler/config/GitLabConfiguration.kt
+++ b/github-crawler-autoconfigure/src/main/kotlin/com/societegenerale/githubcrawler/config/GitLabConfiguration.kt
@@ -4,12 +4,12 @@ package com.societegenerale.githubcrawler.config
 import com.societegenerale.githubcrawler.GitHubCrawlerProperties
 import com.societegenerale.githubcrawler.remote.RemoteGitHub
 import com.societegenerale.githubcrawler.remote.RemoteGitLabImpl
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.context.annotation.Profile
 
 @Configuration
-@Profile("gitLab")
+@ConditionalOnProperty(prefix = "github-crawler.githubConfig", name = ["type"], havingValue = "GITLAB")
 open class GitLabConfiguration {
 
     @Bean

--- a/github-crawler-core/pom.xml
+++ b/github-crawler-core/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.societegenerale.github-crawler</groupId>
     <artifactId>github-crawler-core</artifactId>
-    <version>1.2.2-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>github-crawler-core</name>
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.societegenerale.github-crawler</groupId>
         <artifactId>github-crawler-parent</artifactId>
-        <version>1.2.2-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/GithubConfig.kt
+++ b/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/GithubConfig.kt
@@ -4,7 +4,12 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 
 
 @ConfigurationProperties("github-crawler.githubConfig")
-class GithubConfig(var apiUrl: String="",
+class GithubConfig(var type: SourceControlType = SourceControlType.GITHUB,
+                   var apiUrl: String="",
                    var oauthToken: String="",
                    var organizationName: String="",
                    var crawlUsersRepoInsteadOfOrgasRepos: Boolean=false)
+
+enum class SourceControlType {
+  GITLAB, GITHUB
+}

--- a/github-crawler-core/src/main/resources/application.yml
+++ b/github-crawler-core/src/main/resources/application.yml
@@ -1,6 +1,7 @@
 github-crawler:
 
   githubConfig:
+    type: "GITHUB"
     url: https://api.github.com
     oauthToken: "lihwlfhlihvliwh;wjg;"
     organizationName: MyOrg

--- a/github-crawler-starter/pom.xml
+++ b/github-crawler-starter/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.societegenerale.github-crawler</groupId>
     <artifactId>github-crawler-starter</artifactId>
-    <version>1.2.2-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>github-crawler-starter</name>
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.societegenerale.github-crawler</groupId>
         <artifactId>github-crawler-parent</artifactId>
-        <version>1.2.2-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.societegenerale.github-crawler</groupId>
     <artifactId>github-crawler-parent</artifactId>
-    <version>1.2.2-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>github-crawler</name>


### PR DESCRIPTION
now explicitly declaring which SCM we use (GitHub or Gitlab), to prepare for even more options  