### PR TITLE
feat: bump version to jdk 25 and all the dependencies

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Set up JDK 11
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
           distribution: temurin

--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 25
       - name: Cache Maven dependencies
         uses: actions/cache@v5
         with:

--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 25
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
           server-id: central

--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -22,7 +22,7 @@ jobs:
           version=$(echo "$raw_tag_name" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+$')
           echo "VERSION=$version" >> $GITHUB_ENV
 
-      - name: Set up JDK 11 with GPG
+      - name: Set up JDK 25 with GPG
         uses: actions/setup-java@v5
         with:
           distribution: temurin
@@ -32,6 +32,11 @@ jobs:
           server-id: central
           server-username: CENTRAL_USERNAME
           server-password: CENTRAL_PASSWORD
+
+      - name: Configure git user for release
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
 
       - name: Build & Deploy to Staging
         env:

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,1 @@
+--sun-misc-unsafe-memory-access=allow

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,3 +1,3 @@
 # Enable auto-env through the sdkman_auto_env config
 # Add key=value pairs of SDKs to use below
-java=11.0.31-tem
+java=25.0.3-tem

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,0 +1,3 @@
+# Enable auto-env through the sdkman_auto_env config
+# Add key=value pairs of SDKs to use below
+java=11.0.31-tem

--- a/README.md
+++ b/README.md
@@ -362,3 +362,14 @@ public class PersonalGitHubCrawlerApplication implements CommandLineRunner {
 see [here](https://github.com/vincent-fuchs/my-custom-github-crawler/blob/0e48dd7961b6b625802a2e1eb6b2fc4f8c4d5cdb/src/main/java/com/github/vincent_fuchs/output/CustomOutput.java) or [here](https://github.com/vincent-fuchs/my-custom-github-crawler/blob/ec7ed9a74f91b31794b8a0afb1196553434b1567/src/main/java/com/github/vincent_fuchs/parsers/MyOwnParser.java) for examples
 
 - see the javadoc in [FileContentParser](./github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/parsers/FileContentParser.kt) , [RepoTaskToPerform](./github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/repoTaskToPerform/RepoTaskToPerform.kt), [GitHubCrawlerOutput](./github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/output/GitHubCrawlerOutput.kt) which are the main extension points.
+
+## Versions
+
+-   v3.x is using JDK25
+-   v2.x is using JDK11
+
+## Official maintainers
+
+- [Paul Williams](https://github.com/paul58914080)
+- [Vincent Fuchs](https://github.com/vincent-fuchs)
+

--- a/github-crawler-autoconfigure/pom.xml
+++ b/github-crawler-autoconfigure/pom.xml
@@ -15,31 +15,27 @@
     <dependency>
       <groupId>com.societegenerale.github-crawler</groupId>
       <artifactId>github-crawler-core</artifactId>
-      <version>${project.parent.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-restclient</artifactId>
+    </dependency>
+    <!-- Test dependencies -->
     <dependency>
       <groupId>net.code-story</groupId>
       <artifactId>http</artifactId>
-      <version>2.104</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-simple</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
-      <version>2.32.0</version>
+      <version>${http.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.jayway.awaitility</groupId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock-standalone</artifactId>
+      <version>${wiremock-standalone.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
-      <version>1.7.0</version>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/github-crawler-autoconfigure/pom.xml
+++ b/github-crawler-autoconfigure/pom.xml
@@ -1,58 +1,45 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>github-crawler-autoconfigure</artifactId>
+  <packaging>jar</packaging>
+  <name>github-crawler-autoconfigure</name>
+  <parent>
     <groupId>com.societegenerale.github-crawler</groupId>
-    <artifactId>github-crawler-autoconfigure</artifactId>
+    <artifactId>github-crawler-parent</artifactId>
     <version>2.2.1-SNAPSHOT</version>
-    <packaging>jar</packaging>
-
-    <name>github-crawler-autoconfigure</name>
-
-    <parent>
-        <groupId>com.societegenerale.github-crawler</groupId>
-        <artifactId>github-crawler-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
-    </parent>
-
-    <dependencies>
-
-        <dependency>
-            <groupId>com.societegenerale.github-crawler</groupId>
-            <artifactId>github-crawler-core</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>net.code-story</groupId>
-            <artifactId>http</artifactId>
-            <version>2.104</version>
-            <scope>test</scope>
-
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-simple</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8</artifactId>
-            <version>2.32.0</version>
-            <scope>test</scope>
-        </dependency>
-
-
-        <dependency>
-            <groupId>com.jayway.awaitility</groupId>
-            <artifactId>awaitility</artifactId>
-            <version>1.7.0</version>
-            <scope>test</scope>
-        </dependency>
-
-    </dependencies>
-
-
+  </parent>
+  <dependencies>
+    <dependency>
+      <groupId>com.societegenerale.github-crawler</groupId>
+      <artifactId>github-crawler-core</artifactId>
+      <version>${project.parent.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>net.code-story</groupId>
+      <artifactId>http</artifactId>
+      <version>2.104</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-simple</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.github.tomakehurst</groupId>
+      <artifactId>wiremock-jre8</artifactId>
+      <version>2.32.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.jayway.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>1.7.0</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 </project>

--- a/github-crawler-autoconfigure/pom.xml
+++ b/github-crawler-autoconfigure/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>com.societegenerale.github-crawler</groupId>
     <artifactId>github-crawler-parent</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
   <dependencies>
     <dependency>

--- a/github-crawler-autoconfigure/src/test/java/com/societegenerale/githubcrawler/AzureDevopsCrawlerIT.java
+++ b/github-crawler-autoconfigure/src/test/java/com/societegenerale/githubcrawler/AzureDevopsCrawlerIT.java
@@ -102,7 +102,7 @@ class AzureDevopsCrawlerIT {
       assertThat(branchWhereResultWasFound.getName()).isEqualTo("refs/heads/main");
 
       List<String> valueForIndicator=(ArrayList)firstTaskResult.getValue().get("pipelineTemplateLocation");
-      assertThat(valueForIndicator.get(0)).isEqualTo("azure-pipelines.yml");
+      assertThat(valueForIndicator.getFirst()).isEqualTo("azure-pipelines.yml");
   }
 
 

--- a/github-crawler-autoconfigure/src/test/java/com/societegenerale/githubcrawler/BitbucketCrawlerIT.java
+++ b/github-crawler-autoconfigure/src/test/java/com/societegenerale/githubcrawler/BitbucketCrawlerIT.java
@@ -5,21 +5,20 @@ import com.societegenerale.githubcrawler.config.TestConfig;
 import com.societegenerale.githubcrawler.mocks.BitbucketMock;
 import com.societegenerale.githubcrawler.model.Repository;
 import org.assertj.core.api.SoftAssertions;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.io.IOException;
 import java.util.*;
 
-import static com.jayway.awaitility.Awaitility.await;
+
 import static java.util.Map.entry;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.toList;
@@ -27,7 +26,6 @@ import static java.util.stream.Collectors.toSet;
 import static org.assertj.core.api.Assertions.assertThat;
 
 
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = {TestConfig.class, GitHubCrawlerAutoConfiguration.class})
 @ActiveProfiles(profiles = {"bitBucketTest"})
 @DirtiesContext(classMode = ClassMode.BEFORE_CLASS)
@@ -58,8 +56,8 @@ public class BitbucketCrawlerIT {
 
       bitbucketMockServer.start();
 
-      await().atMost(MAX_TIMEOUT_FOR_CRAWLER, SECONDS)
-          .until(() -> assertThat(BitbucketMock.hasStarted()));
+      Awaitility.await().atMost(MAX_TIMEOUT_FOR_CRAWLER, SECONDS)
+          .untilAsserted(() -> assertThat(BitbucketMock.hasStarted()).isTrue());
 
       hasBitbucketMockServerStarted = true;
     }
@@ -94,8 +92,8 @@ public class BitbucketCrawlerIT {
 
     Collection<Repository> processedRepositories = output.getAnalyzedRepositories().values();
 
-    await().atMost(MAX_TIMEOUT_FOR_CRAWLER, SECONDS)
-        .until(() -> assertThat(processedRepositories).hasSize(nbRepositoriesInOrga));
+    Awaitility.await().atMost(MAX_TIMEOUT_FOR_CRAWLER, SECONDS)
+        .untilAsserted(() -> assertThat(processedRepositories).hasSize(nbRepositoriesInOrga));
 
     assertThat(bitbucketMockServer.isHasCalledNextPage()).as("next page wasn't called").isTrue();
 
@@ -125,7 +123,7 @@ public class BitbucketCrawlerIT {
             .containsKeys(pomXmlFile, new FileToParse("pom.xml", null),
         new FileToParse("Jenkinsfile", null), new FileToParse("Dockerfile", null));
 
-    IndicatorDefinition pomXmlIndicatorDefinition1 = crawler.getGitHubCrawlerProperties().getIndicatorsToFetchByFile().get(pomXmlFile).get(0);
+    IndicatorDefinition pomXmlIndicatorDefinition1 = crawler.getGitHubCrawlerProperties().getIndicatorsToFetchByFile().get(pomXmlFile).getFirst();
     assertThat(pomXmlIndicatorDefinition1).isNotNull();
     assertThat(pomXmlIndicatorDefinition1.getName()).isEqualTo("spring_boot_starter_parent_version");
     assertThat(pomXmlIndicatorDefinition1.getType()).isEqualTo("findDependencyVersionInXml");
@@ -140,8 +138,8 @@ public class BitbucketCrawlerIT {
 
     crawler.crawl();
 
-    await().atMost(MAX_TIMEOUT_FOR_CRAWLER, SECONDS)
-        .until(() -> assertThat(bitbucketMockServer.getPomXmlHits()).hasSize(nbRepositoriesInOrga));
+    Awaitility.await().atMost(MAX_TIMEOUT_FOR_CRAWLER, SECONDS)
+        .untilAsserted(() -> assertThat(bitbucketMockServer.getPomXmlHits()).hasSize(nbRepositoriesInOrga));
 
   }
 
@@ -152,10 +150,10 @@ public class BitbucketCrawlerIT {
 
     Collection<Repository> processedRepositories = output.getAnalyzedRepositories().values();
 
-    await().atMost(MAX_TIMEOUT_FOR_CRAWLER, SECONDS)
-        .until(() -> assertThat(processedRepositories).hasSize(nbRepositoriesInOrga));
+    Awaitility.await().atMost(MAX_TIMEOUT_FOR_CRAWLER, SECONDS)
+        .untilAsserted(() -> assertThat(processedRepositories).hasSize(nbRepositoriesInOrga));
 
-    processedRepositories.stream().forEach(repo -> {
+    processedRepositories.forEach(repo -> {
       assertThat(repo.getGroups()).containsExactlyInAnyOrder("bitBucketTest");
     });
 
@@ -182,8 +180,8 @@ public class BitbucketCrawlerIT {
 
     crawler.crawl();
 
-    await().atMost(MAX_TIMEOUT_FOR_CRAWLER, SECONDS)
-        .until(() -> assertThat(output.getAnalyzedRepositories().values()).hasSize(nbRepositoriesInOrga));
+    Awaitility.await().atMost(MAX_TIMEOUT_FOR_CRAWLER, SECONDS)
+        .untilAsserted(() -> assertThat(output.getAnalyzedRepositories().values()).hasSize(nbRepositoriesInOrga));
 
     Collection<Repository> processedRepositories = output.getAnalyzedRepositories().values();
 
@@ -252,8 +250,8 @@ public class BitbucketCrawlerIT {
 
     Collection<Repository> processedRepositories = output.getAnalyzedRepositories().values();
 
-    await().atMost(MAX_TIMEOUT_FOR_CRAWLER, SECONDS)
-        .until(() -> assertThat(processedRepositories).hasSize(nbRepositoriesInOrga));
+    Awaitility.await().atMost(MAX_TIMEOUT_FOR_CRAWLER, SECONDS)
+        .untilAsserted(() -> assertThat(processedRepositories).hasSize(nbRepositoriesInOrga));
 
     for (Repository processedRepository : processedRepositories) {
 
@@ -284,8 +282,8 @@ public class BitbucketCrawlerIT {
     crawler.crawl();
 
     Collection<Repository> actualRepositories = output.getAnalyzedRepositories().values();
-    await().atMost(MAX_TIMEOUT_FOR_CRAWLER, SECONDS)
-        .until(() -> assertThat(actualRepositories).hasSize(nbRepositoriesInOrga));
+    Awaitility.await().atMost(MAX_TIMEOUT_FOR_CRAWLER, SECONDS)
+        .untilAsserted(() -> assertThat(actualRepositories).hasSize(nbRepositoriesInOrga));
 
     assertThat(bitbucketMockServer.getRepoConfigHits()).hasSize(nbRepositoriesInOrga);
 
@@ -303,8 +301,8 @@ public class BitbucketCrawlerIT {
     crawler.crawl();
 
     Collection<Repository> actualRepositories = output.getAnalyzedRepositories().values();
-    await().atMost(MAX_TIMEOUT_FOR_CRAWLER, SECONDS)
-        .until(() -> assertThat(actualRepositories).hasSize(nbRepositoriesInOrga));
+    Awaitility.await().atMost(MAX_TIMEOUT_FOR_CRAWLER, SECONDS)
+        .untilAsserted(() -> assertThat(actualRepositories).hasSize(nbRepositoriesInOrga));
 
     assertThat(actualRepositories.stream().filter(r -> !r.getCrawlerRunId().equals(GitHubCrawler.NO_CRAWLER_RUN_ID_DEFINED))
         .count())

--- a/github-crawler-autoconfigure/src/test/java/com/societegenerale/githubcrawler/GitHubCrawlerIT.java
+++ b/github-crawler-autoconfigure/src/test/java/com/societegenerale/githubcrawler/GitHubCrawlerIT.java
@@ -307,22 +307,21 @@ public class GitHubCrawlerIT {
     assertThat(output.getAnalyzedRepositories()).isEmpty();
     assertThat(githubMockServer.getSearchHitsCount()).isEqualTo(0);
 
-
     crawler.crawl();
 
-    Collection<Repository> actualRepositories = output.getAnalyzedRepositories().values();
     await().atMost(MAX_TIMEOUT_FOR_CRAWLER, SECONDS)
-        .untilAsserted(() -> assertThat(actualRepositories).hasSize(nbRepositoriesInOrga));
+        .untilAsserted(() -> {
+          assertThat(output.getAnalyzedRepositories().values()).hasSize(nbRepositoriesInOrga);
+          assertThat(githubMockServer.getSearchHitsCount()).isEqualTo(nbRepositoriesInOrga);
+        });
 
-    assertThat(githubMockServer.getSearchHitsCount()).isEqualTo(nbRepositoriesInOrga);
+    Collection<Repository> actualRepositories = new ArrayList<>(output.getAnalyzedRepositories().values());
 
     actualRepositories.forEach(repo -> {
-
       assertThat(repo.getMiscTasksResults()).hasSize(1);
 
-			Map masterMiscTaskResults=repo.getMiscTasksResults().get(new Branch("master"));
-      assertThat(masterMiscTaskResults).containsEntry("nbOfMetricsInPomXml","2");
-
+      Map<String, Object> masterMiscTaskResults = repo.getMiscTasksResults().get(new Branch("master"));
+      assertThat(masterMiscTaskResults).containsEntry("nbOfMetricsInPomXml", "2");
     });
   }
 

--- a/github-crawler-autoconfigure/src/test/java/com/societegenerale/githubcrawler/GitHubCrawlerIT.java
+++ b/github-crawler-autoconfigure/src/test/java/com/societegenerale/githubcrawler/GitHubCrawlerIT.java
@@ -1,10 +1,11 @@
 package com.societegenerale.githubcrawler;
 
-import static com.jayway.awaitility.Awaitility.await;
+
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 import com.societegenerale.githubcrawler.config.GitHubCrawlerAutoConfiguration;
 import com.societegenerale.githubcrawler.config.TestConfig;
@@ -23,16 +24,13 @@ import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = {TestConfig.class, GitHubCrawlerAutoConfiguration.class})
 @ActiveProfiles(profiles = {"gitHubTest", "profilesAreAWayOfGrouping"})
 @DirtiesContext(classMode = ClassMode.BEFORE_CLASS)
@@ -64,7 +62,7 @@ public class GitHubCrawlerIT {
       githubMockServer.start();
 
       await().atMost(MAX_TIMEOUT_FOR_CRAWLER, SECONDS)
-          .until(() -> assertThat(GitHubMock.hasStarted()));
+          .untilAsserted(() -> assertThat(GitHubMock.hasStarted()));
 
       hasGitHubMockServerStarted = true;
     }
@@ -100,7 +98,7 @@ public class GitHubCrawlerIT {
     Collection<Repository> processedRepositories = output.getAnalyzedRepositories().values();
 
     await().atMost(MAX_TIMEOUT_FOR_CRAWLER, SECONDS)
-        .until(() -> assertThat(processedRepositories).hasSize(nbRepositoriesInOrga));
+        .untilAsserted(() -> assertThat(processedRepositories).hasSize(nbRepositoriesInOrga));
 
     assertThat(githubMockServer.isHasCalledNextPage()).as("next page wasn't called").isTrue();
 
@@ -129,7 +127,7 @@ public class GitHubCrawlerIT {
     assertThat(crawler.getGitHubCrawlerProperties().getIndicatorsToFetchByFile()).containsKeys(pomXmlFile, new FileToParse("pom.xml", null),
         new FileToParse("Jenkinsfile", null), new FileToParse("Dockerfile", null));
 
-    IndicatorDefinition pomXmlIndicatorDefinition1 = crawler.getGitHubCrawlerProperties().getIndicatorsToFetchByFile().get(pomXmlFile).get(0);
+    IndicatorDefinition pomXmlIndicatorDefinition1 = crawler.getGitHubCrawlerProperties().getIndicatorsToFetchByFile().get(pomXmlFile).getFirst();
     assertThat(pomXmlIndicatorDefinition1).isNotNull();
     assertThat(pomXmlIndicatorDefinition1.getName()).isEqualTo("spring_boot_starter_parent_version");
     assertThat(pomXmlIndicatorDefinition1.getType()).isEqualTo("findDependencyVersionInXml");
@@ -147,7 +145,7 @@ public class GitHubCrawlerIT {
     crawler.crawl();
 
     await().atMost(MAX_TIMEOUT_FOR_CRAWLER, SECONDS)
-        .until(() -> assertThat(githubMockServer.getPomXmlHits()).hasSize(nbRepositoriesInOrga));
+        .untilAsserted(() -> assertThat(githubMockServer.getPomXmlHits()).hasSize(nbRepositoriesInOrga));
 
   }
 
@@ -159,9 +157,9 @@ public class GitHubCrawlerIT {
     Collection<Repository> processedRepositories = output.getAnalyzedRepositories().values();
 
     await().atMost(MAX_TIMEOUT_FOR_CRAWLER, SECONDS)
-        .until(() -> assertThat(processedRepositories).hasSize(nbRepositoriesInOrga));
+        .untilAsserted(() -> assertThat(processedRepositories).hasSize(nbRepositoriesInOrga));
 
-    processedRepositories.stream().forEach(repo -> {
+    processedRepositories.forEach(repo -> {
       assertThat(repo.getGroups()).containsExactlyInAnyOrder("gitHubTest", "profilesAreAWayOfGrouping");
     });
 
@@ -189,7 +187,7 @@ public class GitHubCrawlerIT {
     crawler.crawl();
 
     await().atMost(MAX_TIMEOUT_FOR_CRAWLER, SECONDS)
-        .until(() -> assertThat(output.getAnalyzedRepositories().values()).hasSize(nbRepositoriesInOrga));
+        .untilAsserted(() -> assertThat(output.getAnalyzedRepositories().values()).hasSize(nbRepositoriesInOrga));
 
     Collection<Repository> processedRepositories = output.getAnalyzedRepositories().values();
 
@@ -259,7 +257,7 @@ public class GitHubCrawlerIT {
     Collection<Repository> processedRepositories = output.getAnalyzedRepositories().values();
 
     await().atMost(MAX_TIMEOUT_FOR_CRAWLER, SECONDS)
-        .until(() -> assertThat(processedRepositories).hasSize(nbRepositoriesInOrga));
+        .untilAsserted(() -> assertThat(processedRepositories).hasSize(nbRepositoriesInOrga));
 
     for (Repository processedRepository : processedRepositories) {
 
@@ -291,7 +289,7 @@ public class GitHubCrawlerIT {
 
     Collection<Repository> actualRepositories = output.getAnalyzedRepositories().values();
     await().atMost(MAX_TIMEOUT_FOR_CRAWLER, SECONDS)
-        .until(() -> assertThat(actualRepositories).hasSize(nbRepositoriesInOrga));
+        .untilAsserted(() -> assertThat(actualRepositories).hasSize(nbRepositoriesInOrga));
 
     assertThat(githubMockServer.getRepoConfigHits()).hasSize(nbRepositoriesInOrga);
 
@@ -314,11 +312,11 @@ public class GitHubCrawlerIT {
 
     Collection<Repository> actualRepositories = output.getAnalyzedRepositories().values();
     await().atMost(MAX_TIMEOUT_FOR_CRAWLER, SECONDS)
-        .until(() -> assertThat(actualRepositories).hasSize(nbRepositoriesInOrga));
+        .untilAsserted(() -> assertThat(actualRepositories).hasSize(nbRepositoriesInOrga));
 
     assertThat(githubMockServer.getSearchHitsCount()).isEqualTo(nbRepositoriesInOrga);
 
-    actualRepositories.stream().forEach(repo -> {
+    actualRepositories.forEach(repo -> {
 
       assertThat(repo.getMiscTasksResults()).hasSize(1);
 
@@ -335,7 +333,7 @@ public class GitHubCrawlerIT {
 
     Collection<Repository> actualRepositories = output.getAnalyzedRepositories().values();
     await().atMost(MAX_TIMEOUT_FOR_CRAWLER, SECONDS)
-        .until(() -> assertThat(actualRepositories).hasSize(nbRepositoriesInOrga));
+        .untilAsserted(() -> assertThat(actualRepositories).hasSize(nbRepositoriesInOrga));
 
     assertThat(actualRepositories.stream().filter(r -> !r.getCrawlerRunId().equals(GitHubCrawler.NO_CRAWLER_RUN_ID_DEFINED))
         .count())

--- a/github-crawler-autoconfigure/src/test/java/com/societegenerale/githubcrawler/RemoteGitHubImplTest.kt
+++ b/github-crawler-autoconfigure/src/test/java/com/societegenerale/githubcrawler/RemoteGitHubImplTest.kt
@@ -1,9 +1,10 @@
 package com.societegenerale.githubcrawler
 
-import com.jayway.awaitility.Awaitility.await
+
 import com.societegenerale.githubcrawler.mocks.GitHubMock
 import com.societegenerale.githubcrawler.remote.RemoteGitHubImpl
 import org.assertj.core.api.Assertions.assertThat
+import org.awaitility.Awaitility
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
@@ -30,8 +31,8 @@ class RemoteGitHubImplTest {
 
             githubMockServer.start()
 
-            await().atMost(5, SECONDS)
-                    .until{ assertThat(GitHubMock.hasStarted()) }
+            Awaitility.await().atMost(5, SECONDS)
+                .untilAsserted { assertThat(GitHubMock.hasStarted()).isTrue() }
         }
 
         @AfterAll

--- a/github-crawler-autoconfigure/src/test/java/com/societegenerale/githubcrawler/RemoteGitLabImplTest.kt
+++ b/github-crawler-autoconfigure/src/test/java/com/societegenerale/githubcrawler/RemoteGitLabImplTest.kt
@@ -1,10 +1,11 @@
 package com.societegenerale.githubcrawler
 
-import com.jayway.awaitility.Awaitility.await
+
 import com.societegenerale.githubcrawler.mocks.GitLabMock
 import com.societegenerale.githubcrawler.mocks.RemoteServiceMock.GITLAB_MOCK_PORT
 import com.societegenerale.githubcrawler.remote.RemoteGitLabImpl
 import org.assertj.core.api.Assertions.assertThat
+import org.awaitility.Awaitility
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
@@ -24,7 +25,7 @@ class RemoteGitLabImplTest {
 
     companion object {
 
-        val gitlabMockServer: GitLabMock = GitLabMock();
+        val gitlabMockServer: GitLabMock = GitLabMock()
 
         @BeforeAll
         @JvmStatic
@@ -32,8 +33,8 @@ class RemoteGitLabImplTest {
 
             gitlabMockServer.start()
 
-            await().atMost(5, SECONDS)
-                    .until{ assertThat(GitLabMock.hasStarted()) }
+            Awaitility.await().atMost(5, SECONDS)
+                    .untilAsserted { assertThat(GitLabMock.hasStarted()).isTrue() }
         }
 
         @AfterAll
@@ -49,7 +50,7 @@ class RemoteGitLabImplTest {
         gitlabMockServer.reset()
     }
 
-    val remoteGitLab = RemoteGitLabImpl("http://localhost:"+GITLAB_MOCK_PORT+"/api/v4",  "someToken");
+    val remoteGitLab = RemoteGitLabImpl("http://localhost:"+GITLAB_MOCK_PORT+"/api/v4",  "someToken")
 
     @Test
     fun shouldGetRepositoriesForAgroup() {
@@ -90,7 +91,7 @@ class RemoteGitLabImplTest {
 
         val searchResults=remoteGitLab.fetchCodeSearchResult("h5bp/html5-boilerplate","blabla")
 
-        assertThat(searchResults.totalCount).isEqualTo(2);
+        assertThat(searchResults.totalCount).isEqualTo(2)
     }
 
 

--- a/github-crawler-autoconfigure/src/test/java/com/societegenerale/githubcrawler/config/TestConfig.java
+++ b/github-crawler-autoconfigure/src/test/java/com/societegenerale/githubcrawler/config/TestConfig.java
@@ -3,8 +3,8 @@ package com.societegenerale.githubcrawler.config;
 import com.societegenerale.githubcrawler.GitHubCrawlerProperties;
 import com.societegenerale.githubcrawler.model.Repository;
 import com.societegenerale.githubcrawler.output.GitHubCrawlerOutput;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -21,7 +21,7 @@ public class TestConfig {
 
     public static class InMemoryGitHubCrawlerOutput implements GitHubCrawlerOutput {
 
-        private final Map<String, Repository> analyzedRepositories = new HashMap<>();
+        private final Map<String, Repository> analyzedRepositories = new ConcurrentHashMap<>();
 
         public Map<String, Repository> getAnalyzedRepositories() {
             return analyzedRepositories;

--- a/github-crawler-autoconfigure/src/test/java/com/societegenerale/githubcrawler/mocks/BitbucketMock.java
+++ b/github-crawler-autoconfigure/src/test/java/com/societegenerale/githubcrawler/mocks/BitbucketMock.java
@@ -86,27 +86,27 @@ public class BitbucketMock implements RemoteServiceMock {
         bitbucketWebServer = new WebServer();
         bitbucketWebServer.configure(
                 routes -> {
-                    routes.get("/projects/myProject/repos/:repo/raw/.BitBucketCrawler?at=master", (context, repo) -> getRepoConfigFileOnRepo(repo));
-                    routes.get("/projects/myProject/repos/:repo/raw/pom.xml?at=master", (context, repo) -> getPomXmlFileOnRepo(repo));
-                    routes.get("/projects/myProject/repos?start=:start", (context, start) -> getOrganisationContent(Integer.parseInt(start)));
+                    routes.get("/projects/myProject/repos/:repo/raw/.BitBucketCrawler?at=master", (_, repo) -> getRepoConfigFileOnRepo(repo));
+                    routes.get("/projects/myProject/repos/:repo/raw/pom.xml?at=master", (_, repo) -> getPomXmlFileOnRepo(repo));
+                    routes.get("/projects/myProject/repos?start=:start", (_, start) -> getOrganisationContent(Integer.parseInt(start)));
 
                     //for other resources than pom.xml..
                     //hack for resources that are not at the root of the repository, so that we don't have to hardcode too many things
                     routes.get("/projects/myProject/repos/:repo/raw/:aSubDirectory/:resource?at=:branchName",
-                            (context, repo, aSubDirectory, resource, branchName) -> getResource(repo, aSubDirectory, resource, branchName));
+                            (_, repo, aSubDirectory, resource, branchName) -> getResource(repo, aSubDirectory, resource, branchName));
 
                     routes.get("/projects/myProject/repos/:repo/contents/:resource?ref=:branchName",
-                            (context, repo, resource, branchName) -> getResourceFileOnRepo(repo, resource, null, branchName));
+                            (_, repo, resource, branchName) -> getResourceFileOnRepo(repo, resource, null, branchName));
                     routes.get("/raw/myProject/:repo/:branchName/:resource",
-                            (context, repo, branchName, resource) -> getResource(repo, branchName, null, resource));
+                            (_, repo, branchName, resource) -> getResource(repo, branchName, null, resource));
 
-                    routes.get("/projects/myProject/repos/:repo/branches", (context, repo) -> getBranches(repo));
+                    routes.get("/projects/myProject/repos/:repo/branches", (_, repo) -> getBranches(repo));
 
                     routes.get("/admin/groups", this::getTeams);
-                    routes.get("/api/v3/teams/:team/members", (context, team) -> getTeamsMembers(team));
+                    routes.get("/api/v3/teams/:team/members", (_, team) -> getTeamsMembers(team));
 
-                    routes.get("/projects/myProject/repos/:repo/commits?limit=1", (context, repo) -> getCommits(repo));
-                    routes.get("/projects/myProject/repos/:repo/commits/:commit", (context, repo, commit) -> getCommit(repo, commit));
+                    routes.get("/projects/myProject/repos/:repo/commits?limit=1", (_, repo) -> getCommits(repo));
+                    routes.get("/projects/myProject/repos/:repo/commits/:commit", (_, repo, commit) -> getCommit(repo, commit));
 
                 }
         ).start(BITBUCKET_MOCK_PORT);

--- a/github-crawler-autoconfigure/src/test/java/com/societegenerale/githubcrawler/mocks/BitbucketMock.java
+++ b/github-crawler-autoconfigure/src/test/java/com/societegenerale/githubcrawler/mocks/BitbucketMock.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 
 @Component
@@ -53,9 +54,9 @@ public class BitbucketMock implements RemoteServiceMock {
         return hasCalledNextPage;
     }
 
-    private List<String> repoConfigHits = new ArrayList<>();
+    private List<String> repoConfigHits = new CopyOnWriteArrayList<>();
 
-    private List<String> pomXmlHits = new ArrayList<>();
+    private List<String> pomXmlHits = new CopyOnWriteArrayList<>();
 
     private int nbPages = 1;
 

--- a/github-crawler-autoconfigure/src/test/java/com/societegenerale/githubcrawler/mocks/GitHubMock.java
+++ b/github-crawler-autoconfigure/src/test/java/com/societegenerale/githubcrawler/mocks/GitHubMock.java
@@ -11,6 +11,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 import net.codestory.http.Context;
 import net.codestory.http.WebServer;
 import net.codestory.http.constants.HttpStatus;
@@ -57,9 +58,9 @@ public class GitHubMock implements RemoteServiceMock {
         return hasCalledNextPage;
     }
 
-    private List<String> repoConfigHits = new ArrayList<>();
+    private List<String> repoConfigHits = new CopyOnWriteArrayList<>();
 
-    private List<String> pomXmlHits = new ArrayList<>();
+    private List<String> pomXmlHits = new CopyOnWriteArrayList<>();
 
     private int nbPages = 1;
 
@@ -91,38 +92,38 @@ public class GitHubMock implements RemoteServiceMock {
         gitHubWebServer.configure(
                 routes -> {
 
-                    routes.get("/api/v3/repos/MyOrganization/:repo/contents/.githubCrawler", (context, repo) -> getRepoConfigFileOnRepo(repo));
-                    routes.get("/raw/MyOrganization/:repo/master/.githubCrawler", (context, repo) -> getActualRepoConfig(repo));
+                    routes.get("/api/v3/repos/MyOrganization/:repo/contents/.githubCrawler", (_, repo) -> getRepoConfigFileOnRepo(repo));
+                    routes.get("/raw/MyOrganization/:repo/master/.githubCrawler", (_, repo) -> getActualRepoConfig(repo));
 
                     routes.get("/api/v3/orgs/MyOrganization/repos", context -> getOrganisationContent(context));
-                    routes.get("/api/v3/organizations/1114/repos", context -> getOrganisationContentForNextPage());
+                    routes.get("/api/v3/organizations/1114/repos", _ -> getOrganisationContentForNextPage());
 
-                    routes.get("/api/v3/users/someUser/repos", context -> geUserReposContent());
+                    routes.get("/api/v3/users/someUser/repos", _ -> geUserReposContent());
 
-                    routes.get("/api/v3/repos/MyOrganization/:repo/contents/pom.xml?ref=master", (context, repo) -> getPomXmlFileOnRepo(repo));
-                    routes.get("/raw/MyOrganization/:repo/:branchName/pom.xml", (context, repo, branchName) -> getActualPomXML(repo, branchName));
+                    routes.get("/api/v3/repos/MyOrganization/:repo/contents/pom.xml?ref=master", (_, repo) -> getPomXmlFileOnRepo(repo));
+                    routes.get("/raw/MyOrganization/:repo/:branchName/pom.xml", (_, repo, branchName) -> getActualPomXML(repo, branchName));
 
                     //for other resources than pom.xml..
                     //hack for resources that are not at the root of the repository, so that we don't have to hardcode too many things
                     routes.get("/api/v3/repos/MyOrganization/:repo/contents/:aSubDirectory/:resource?ref=:branchName",
-                            (context, repo, aSubDirectory, resource, branchName) -> getResourceFileOnRepo(repo, resource, aSubDirectory, branchName));
+                            (_, repo, aSubDirectory, resource, branchName) -> getResourceFileOnRepo(repo, resource, aSubDirectory, branchName));
                     routes.get("/raw/MyOrganization/:repo/:branchName/:aSubDirectory/:resource",
-                            (context, repo, branchName, aSubDirectory, resource) -> getResource(repo, branchName, aSubDirectory, resource));
+                            (_, repo, branchName, aSubDirectory, resource) -> getResource(repo, branchName, aSubDirectory, resource));
 
                     routes.get("/api/v3/repos/MyOrganization/:repo/contents/:resource?ref=:branchName",
-                            (context, repo, resource, branchName) -> getResourceFileOnRepo(repo, resource, null, branchName));
+                            (_, repo, resource, branchName) -> getResourceFileOnRepo(repo, resource, null, branchName));
                     routes.get("/raw/MyOrganization/:repo/:branchName/:resource",
-                            (context, repo, branchName, resource) -> getResource(repo, branchName, null, resource));
+                            (_, repo, branchName, resource) -> getResource(repo, branchName, null, resource));
 
-                    routes.get("/api/v3/repos/MyOrganization/:repo/branches", (context, repo) -> getBranches(repo));
+                    routes.get("/api/v3/repos/MyOrganization/:repo/branches", (_, repo) -> getBranches(repo));
 
-                    routes.get("/api/v3/search/code?q=:searchQuery", (context, searchQuery) -> getSearchResult(searchQuery));
+                    routes.get("/api/v3/search/code?q=:searchQuery", (_, searchQuery) -> getSearchResult(searchQuery));
 
                     routes.get("/api/v3/orgs/MyOrganization/teams", this::getTeams);
-                    routes.get("/api/v3/teams/:team/members", (context, team) -> getTeamsMembers(team));
+                    routes.get("/api/v3/teams/:team/members", (_, team) -> getTeamsMembers(team));
 
-                    routes.get("/api/v3/repos/MyOrganization/:repo/commits?per_page=150", (context, repo) -> getCommits(repo));
-                    routes.get("/api/v3/repos/MyOrganization/:repo/commits/:commit", (context, repo, commit) -> getCommit(repo, commit));
+                    routes.get("/api/v3/repos/MyOrganization/:repo/commits?per_page=150", (_, repo) -> getCommits(repo));
+                    routes.get("/api/v3/repos/MyOrganization/:repo/commits/:commit", (_, repo, commit) -> getCommit(repo, commit));
 
                 }
         ).start(GITHUB_MOCK_PORT);

--- a/github-crawler-autoconfigure/src/test/java/com/societegenerale/githubcrawler/mocks/GitLabMock.java
+++ b/github-crawler-autoconfigure/src/test/java/com/societegenerale/githubcrawler/mocks/GitLabMock.java
@@ -36,12 +36,12 @@ public class GitLabMock implements RemoteServiceMock {
         gitLabWebServer.configure(
                 routes -> {
 
-                    routes.get("/api/v4/groups?search=:groupName", (context,groupName) -> getGroups(groupName));
+                    routes.get("/api/v4/groups?search=:groupName", (_,groupName) -> getGroups(groupName));
 
-                    routes.get("/api/v4/groups/:groupId/projects", (context, groupId) -> getRepositories(groupId));
-                    routes.get("/api/v4/projects/:repoId/repository/files/:filePath/raw?ref=:branchName", (context, repoId, filePath,branchName) -> getFileContent(repoId, filePath, branchName));
+                    routes.get("/api/v4/groups/:groupId/projects", (_, groupId) -> getRepositories(groupId));
+                    routes.get("/api/v4/projects/:repoId/repository/files/:filePath/raw?ref=:branchName", (_, repoId, filePath,branchName) -> getFileContent(repoId, filePath, branchName));
 
-                    routes.get("/api/v4/projects/:repoId/search?scope=blobs&:searchString", (context, repoId, searchString) -> getRepoSearchResults(repoId, searchString));
+                    routes.get("/api/v4/projects/:repoId/search?scope=blobs&:searchString", (_, repoId, searchString) -> getRepoSearchResults(repoId, searchString));
 
 
                 }

--- a/github-crawler-core/pom.xml
+++ b/github-crawler-core/pom.xml
@@ -1,163 +1,129 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>github-crawler-core</artifactId>
+  <packaging>jar</packaging>
+  <name>github-crawler-core</name>
+  <parent>
     <groupId>com.societegenerale.github-crawler</groupId>
-    <artifactId>github-crawler-core</artifactId>
+    <artifactId>github-crawler-parent</artifactId>
     <version>2.2.1-SNAPSHOT</version>
-    <packaging>jar</packaging>
-
-    <name>github-crawler-core</name>
-
-    <parent>
-        <groupId>com.societegenerale.github-crawler</groupId>
-        <artifactId>github-crawler-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
-    </parent>
-
-    <dependencies>
-
-        <!--
-            Theoretically, we don't need to declare gson lib, as it's provided by spring-cloud-starter-openfeign .
-            The gson version is overridden in spring boot starter (to 2.8.5 as of Spring Boot 2.0.4)
-            However, when starter is built and used elsewhere, the version switches back to the one defined in spring-cloud-starter-openfeign
-            and it doesn't work
-
-            more infos : https://stackoverflow.com/questions/52143687/not-getting-the-expected-version-when-using-the-spring-boot-starter-i-built
-         -->
-
-        <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-            <version>${gson.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-logging</artifactId>
-
-            <exclusions>
-
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-simple</artifactId>
-                </exclusion>
-
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-openfeign</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.github.openfeign</groupId>
-            <artifactId>feign-gson</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.github.openfeign</groupId>
-            <artifactId>feign-httpclient</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.module</groupId>
-            <artifactId>jackson-module-kotlin</artifactId>
-
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jetbrains.kotlin</groupId>
-                    <artifactId>kotlin-reflect</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.dataformat</groupId>
-            <artifactId>jackson-dataformat-yaml</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>2.11.0</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.7</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-        </dependency>
-
-
-        <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>logging-interceptor</artifactId>
-        </dependency>
-
-
-        <dependency>
-            <groupId>com.jayway.awaitility</groupId>
-            <artifactId>awaitility</artifactId>
-            <version>1.7.0</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.jayway.jsonpath</groupId>
-            <artifactId>json-path</artifactId>
-            <version>2.7.0</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <optional>true</optional>
-        </dependency>
-
-    </dependencies>
-
-    <build>
-
-        <plugins>
-            <plugin>
-                <artifactId>kotlin-maven-plugin</artifactId>
-                <groupId>org.jetbrains.kotlin</groupId>
-                <version>${kotlin.version}</version>
-
-                <executions>
-                    <execution>
-                        <id>kapt</id>
-                        <goals>
-                            <goal>kapt</goal>
-                        </goals>
-                        <configuration>
-                            <sourceDirs>
-                                <sourceDir>src/main/kotlin</sourceDir>
-                            </sourceDirs>
-
-                            <annotationProcessorPaths>
-
-
-                                <!-- Specify your annotation processors here. -->
-                                <annotationProcessorPath>
-                                    <groupId>com.google.dagger</groupId>
-                                    <artifactId>dagger-compiler</artifactId>
-                                    <version>2.9</version>
-                                </annotationProcessorPath>
-                            </annotationProcessorPaths>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
-
+  </parent>
+  <dependencies>
+    <!--
+        Theoretically, we don't need to declare gson lib, as it's provided by spring-cloud-starter-openfeign .
+        The gson version is overridden in spring boot starter (to 2.8.5 as of Spring Boot 2.0.4)
+        However, when starter is built and used elsewhere, the version switches back to the one defined in spring-cloud-starter-openfeign
+        and it doesn't work
+        more infos : https://stackoverflow.com/questions/52143687/not-getting-the-expected-version-when-using-the-spring-boot-starter-i-built
+     -->
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>${gson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-logging</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-simple</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-starter-openfeign</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.github.openfeign</groupId>
+      <artifactId>feign-gson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.github.openfeign</groupId>
+      <artifactId>feign-httpclient</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-kotlin</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jetbrains.kotlin</groupId>
+          <artifactId>kotlin-reflect</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-yaml</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.11.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.7</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>logging-interceptor</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.jayway.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>1.7.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.jayway.jsonpath</groupId>
+      <artifactId>json-path</artifactId>
+      <version>2.7.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-configuration-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>kotlin-maven-plugin</artifactId>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <version>${kotlin.version}</version>
+        <executions>
+          <execution>
+            <id>kapt</id>
+            <goals>
+              <goal>kapt</goal>
+            </goals>
+            <configuration>
+              <sourceDirs>
+                <sourceDir>src/main/kotlin</sourceDir>
+              </sourceDirs>
+              <annotationProcessorPaths>
+                <!-- Specify your annotation processors here. -->
+                <annotationProcessorPath>
+                  <groupId>com.google.dagger</groupId>
+                  <artifactId>dagger-compiler</artifactId>
+                  <version>2.9</version>
+                </annotationProcessorPath>
+              </annotationProcessorPaths>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/github-crawler-core/pom.xml
+++ b/github-crawler-core/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>com.societegenerale.github-crawler</groupId>
     <artifactId>github-crawler-parent</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
   <dependencies>
     <!--

--- a/github-crawler-core/pom.xml
+++ b/github-crawler-core/pom.xml
@@ -27,12 +27,6 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-logging</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-simple</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework.cloud</groupId>
@@ -47,29 +41,17 @@
       <artifactId>feign-httpclient</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.module</groupId>
+      <groupId>tools.jackson.module</groupId>
       <artifactId>jackson-module-kotlin</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.jetbrains.kotlin</groupId>
-          <artifactId>kotlin-reflect</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <groupId>tools.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.11.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <version>3.7</version>
-      <scope>test</scope>
+      <version>${commons-io.version}</version>
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
@@ -80,20 +62,24 @@
       <artifactId>logging-interceptor</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.jayway.awaitility</groupId>
-      <artifactId>awaitility</artifactId>
-      <version>1.7.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.jayway.jsonpath</groupId>
       <artifactId>json-path</artifactId>
-      <version>2.7.0</version>
+      <version>${json-path.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-configuration-processor</artifactId>
       <optional>true</optional>
+    </dependency>
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
     </dependency>
   </dependencies>
   <build>
@@ -117,7 +103,7 @@
                 <annotationProcessorPath>
                   <groupId>com.google.dagger</groupId>
                   <artifactId>dagger-compiler</artifactId>
-                  <version>2.9</version>
+                  <version>2.60.1</version>
                 </annotationProcessorPath>
               </annotationProcessorPaths>
             </configuration>

--- a/github-crawler-core/pom.xml
+++ b/github-crawler-core/pom.xml
@@ -66,11 +66,6 @@
       <artifactId>json-path</artifactId>
       <version>${json-path.version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-configuration-processor</artifactId>
-      <optional>true</optional>
-    </dependency>
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -104,6 +99,11 @@
                   <groupId>com.google.dagger</groupId>
                   <artifactId>dagger-compiler</artifactId>
                   <version>2.60.1</version>
+                </annotationProcessorPath>
+                <annotationProcessorPath>
+                  <groupId>org.springframework.boot</groupId>
+                  <artifactId>spring-boot-configuration-processor</artifactId>
+                  <version>${spring-boot-dependencies.version}</version>
                 </annotationProcessorPath>
               </annotationProcessorPaths>
             </configuration>

--- a/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/FileToParse.kt
+++ b/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/FileToParse.kt
@@ -18,7 +18,7 @@ class FileToParseConversionService : ConversionService {
         return targetType.name == FileToParse::class.java.name
     }
 
-    override fun <T : Any?> convert(@Nullable o: Any?, targetType: Class<T>): T? {
+    override fun <T : Any> convert(source: Any?, targetType: Class<T>): T? {
         return null
     }
 

--- a/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/FileToParse.kt
+++ b/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/FileToParse.kt
@@ -2,7 +2,6 @@ package com.societegenerale.githubcrawler
 
 import org.springframework.core.convert.ConversionService
 import org.springframework.core.convert.TypeDescriptor
-import org.springframework.lang.Nullable
 
 
 data class FileToParse(val name: String,
@@ -10,11 +9,11 @@ data class FileToParse(val name: String,
 
 class FileToParseConversionService : ConversionService {
 
-    override fun canConvert(@Nullable aClass: Class<*>?, aClass1: Class<*>): Boolean {
+    override fun canConvert(aClass: Class<*>?, aClass1: Class<*>): Boolean {
         return false
     }
 
-    override fun canConvert(@Nullable sourcetype: TypeDescriptor?, targetType: TypeDescriptor): Boolean {
+    override fun canConvert(sourcetype: TypeDescriptor?, targetType: TypeDescriptor): Boolean {
         return targetType.name == FileToParse::class.java.name
     }
 
@@ -22,7 +21,7 @@ class FileToParseConversionService : ConversionService {
         return null
     }
 
-    override fun convert(@Nullable value: Any?, @Nullable sourceType: TypeDescriptor?, targetType: TypeDescriptor): Any? {
+    override fun convert(value: Any?, sourceType: TypeDescriptor?, targetType: TypeDescriptor): Any? {
 
         return if (targetType.name == FileToParse::class.java.name) {
             FileToParse(value as String, null)

--- a/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/model/bitbucket/Repositories.kt
+++ b/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/model/bitbucket/Repositories.kt
@@ -5,6 +5,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class Repositories(val values: Set<Repository>,
                         val isLastPage: Boolean,
-                        val start: Int,
-                        val nextPageStart: Int,
+                        val start: Int = 0,
+                        val nextPageStart: Int = 0,
                         )

--- a/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/output/CIdroidReadyJsonFileOutput.kt
+++ b/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/output/CIdroidReadyJsonFileOutput.kt
@@ -8,7 +8,7 @@ import java.io.IOException
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.OpenOption
-import java.nio.file.Paths
+import java.nio.file.Path
 import java.nio.file.StandardOpenOption
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -113,7 +113,7 @@ class CIdroidReadyJsonFileOutput (val indicatorsToOutput: List<String>, val with
     @Suppress("SpreadOperator") //no performance impact given the number of values (a couple, max)..
     private fun openFileWithOptions(vararg options : OpenOption) : BufferedWriter {
 
-        return Files.newBufferedWriter(Paths.get(finalOutputFileName),
+        return Files.newBufferedWriter(Path.of(finalOutputFileName),
                 StandardCharsets.UTF_8,
                 *options)
     }

--- a/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/output/CsvFileOutput.kt
+++ b/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/output/CsvFileOutput.kt
@@ -5,7 +5,7 @@ import org.slf4j.Logger
 import java.io.IOException
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
-import java.nio.file.Paths
+import java.nio.file.Path
 import java.nio.file.StandardOpenOption
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -34,7 +34,7 @@ abstract class CsvFileOutput(initParam : Any) : GitHubCrawlerOutput{
 
         finalOutputFileName = getPrefix() + now.format(formatter) + ".csv"
 
-        val writer = Files.newBufferedWriter(Paths.get(finalOutputFileName),
+        val writer = Files.newBufferedWriter(Path.of(finalOutputFileName),
                 StandardCharsets.UTF_8,
                 StandardOpenOption.CREATE_NEW)
 
@@ -46,7 +46,7 @@ abstract class CsvFileOutput(initParam : Any) : GitHubCrawlerOutput{
     @Throws(IOException::class)
     override fun output(analyzedRepository: Repository) {
 
-        val writer = Files.newBufferedWriter(Paths.get(finalOutputFileName),
+        val writer = Files.newBufferedWriter(Path.of(finalOutputFileName),
                 StandardCharsets.UTF_8,
                 StandardOpenOption.WRITE, StandardOpenOption.APPEND)
 

--- a/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/output/FileOutput.kt
+++ b/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/output/FileOutput.kt
@@ -5,7 +5,7 @@ import org.slf4j.LoggerFactory
 import java.io.IOException
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
-import java.nio.file.Paths
+import java.nio.file.Path
 import java.nio.file.StandardOpenOption
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -27,7 +27,7 @@ class FileOutput (filenamePrefix: String) : GitHubCrawlerOutput {
 
         finalOutputFileName = filenamePrefix + "_" + now.format(formatter) + ".txt"
 
-        Files.newBufferedWriter(Paths.get(finalOutputFileName),
+        Files.newBufferedWriter(Path.of(finalOutputFileName),
                 StandardCharsets.UTF_8,
                 StandardOpenOption.CREATE_NEW).use{
 
@@ -40,7 +40,7 @@ class FileOutput (filenamePrefix: String) : GitHubCrawlerOutput {
     @Throws(IOException::class)
     override fun output(analyzedRepository: Repository) {
 
-        Files.newBufferedWriter(Paths.get(finalOutputFileName),
+        Files.newBufferedWriter(Path.of(finalOutputFileName),
                 StandardCharsets.UTF_8,
                 StandardOpenOption.WRITE, StandardOpenOption.APPEND).use{
 

--- a/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/output/HttpOutput.kt
+++ b/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/output/HttpOutput.kt
@@ -41,10 +41,10 @@ class HttpOutput(targetUrl: String,
                 response = restTemplate.postForEntity(internalTargetUrl, output, String::class.java)
 
                 if (!response.statusCode.is2xxSuccessful) {
-                    logHttpError(analyzedRepository.name, response.statusCodeValue,response.body)
+                    logHttpError(analyzedRepository.name, response.statusCode.value(),response.body)
                 }
             } catch (e : HttpClientErrorException) {
-                logHttpError(analyzedRepository.name, e.rawStatusCode,e.message ?: "no additional message provided")
+                logHttpError(analyzedRepository.name, e.statusCode.value(),e.message ?: "no additional message provided")
             }
         }
     }

--- a/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/parsers/JsonPathParser.kt
+++ b/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/parsers/JsonPathParser.kt
@@ -3,7 +3,6 @@ package com.societegenerale.githubcrawler.parsers
 import com.jayway.jsonpath.JsonPath.read
 import com.jayway.jsonpath.PathNotFoundException
 import com.societegenerale.githubcrawler.IndicatorDefinition
-import net.minidev.json.JSONArray
 import org.slf4j.LoggerFactory
 
 /**
@@ -50,12 +49,12 @@ class JsonPathParser : FileContentParser {
 
             if (result is String) {
                 result
-            } else if (result is JSONArray && !result.isEmpty()) {
+            } else if (result is List<*> && result.isNotEmpty()) {
                 result[0] as String
             } else {
                 NOT_FOUND
             }
-        } catch (e: PathNotFoundException) {
+        } catch (_: PathNotFoundException) {
             NOT_FOUND
         }
 

--- a/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/remote/CodeSearchRequestDetailsSerializer.kt
+++ b/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/remote/CodeSearchRequestDetailsSerializer.kt
@@ -1,13 +1,13 @@
 package com.societegenerale.githubcrawler.remote
 
-import com.fasterxml.jackson.core.JsonGenerator
+import tools.jackson.core.JsonGenerator
 
-import com.fasterxml.jackson.databind.SerializerProvider
-import com.fasterxml.jackson.databind.ser.std.StdSerializer
+import tools.jackson.databind.ser.std.StdSerializer
+import tools.jackson.databind.SerializationContext
 
 class CodeSearchRequestDetailsSerializer() : StdSerializer<CodeSearchRequestDetails>(CodeSearchRequestDetails::class.java) {
 
-  override fun serialize(p0: CodeSearchRequestDetails?, p1: JsonGenerator?, p2: SerializerProvider?) {
+  override fun serialize(p0: CodeSearchRequestDetails?, p1: JsonGenerator?, p2: SerializationContext?) {
     TODO("Not yet implemented")
   }
 

--- a/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/remote/RemoteAzureDevopsImpl.kt
+++ b/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/remote/RemoteAzureDevopsImpl.kt
@@ -1,11 +1,8 @@
 package com.societegenerale.githubcrawler.remote
 
-import com.fasterxml.jackson.core.JsonParseException
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
-import com.fasterxml.jackson.module.kotlin.KotlinModule
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+
+import tools.jackson.module.kotlin.KotlinModule
+import tools.jackson.module.kotlin.jacksonObjectMapper
 import com.societegenerale.githubcrawler.RepositoryConfig
 import com.societegenerale.githubcrawler.model.*
 import com.societegenerale.githubcrawler.model.azuredevops.Repositories
@@ -22,7 +19,10 @@ import okhttp3.logging.HttpLoggingInterceptor
 import org.apache.commons.io.IOUtils
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
-import java.io.IOException
+import tools.jackson.core.JacksonException
+import tools.jackson.core.exc.StreamReadException
+import tools.jackson.dataformat.yaml.YAMLMapper
+
 import java.io.StringWriter
 import java.util.*
 import java.util.stream.Collectors.toSet
@@ -51,7 +51,7 @@ class RemoteAzureDevopsImpl @JvmOverloads constructor(private val azureDevopsUrl
     private var azureOrg=splitedOrgName.get(0)
     private var azureProject=splitedOrgName.get(1)
 
-    private val objectMapper = jacksonObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+    private val objectMapper = jacksonObjectMapper()
 
     private val basicAuthentCredentials: String = Credentials.basic("", personalAccessToken)
 
@@ -103,7 +103,7 @@ class RemoteAzureDevopsImpl @JvmOverloads constructor(private val azureDevopsUrl
 
             return objectMapper.readValue(bodyAsString, Repositories::class.java)
         }
-        catch( e : JsonParseException){
+        catch( e : StreamReadException){
 
             throw IllegalArgumentException("unable to read the repositories to crawl from the response we got $bodyAsString",e)
         }
@@ -234,12 +234,9 @@ internal class CodeSearchResultItem(val path : String)
 internal class AzureDevopsResponseDecoder {
     val log = LoggerFactory.getLogger(this.javaClass)
 
-    val repoConfigMapper = ObjectMapper(YAMLFactory())
-
-    init {
-        repoConfigMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-        repoConfigMapper.registerModule(KotlinModule.Builder().build())
-    }
+    val repoConfigMapper: YAMLMapper = YAMLMapper.builder()
+        .addModule(KotlinModule.Builder().build())
+        .build()
 
     fun decodeRepoConfig(response: okhttp3.Response): RepositoryConfig {
 
@@ -261,7 +258,7 @@ internal class AzureDevopsResponseDecoder {
 
         try {
             return repoConfigMapper.readValue(responseAsString, RepositoryConfig::class.java)
-        } catch (e: IOException) {
+        } catch (e: JacksonException) {
             throw Repository.RepoConfigException(HttpStatus.BAD_REQUEST,"unable to parse config for repo - content : \"" + response.body + "\"", e)
         }
     }

--- a/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/remote/RemoteAzureDevopsImpl.kt
+++ b/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/remote/RemoteAzureDevopsImpl.kt
@@ -146,7 +146,7 @@ class RemoteAzureDevopsImpl @JvmOverloads constructor(private val azureDevopsUrl
 
         val responseBody= httpClient.newCall(request).execute().body
 
-        val repoSearchResult = objectMapper.readValue(responseBody?.string(), CodeSearchResult::class.java)
+        val repoSearchResult = objectMapper.readValue(responseBody.string(), CodeSearchResult::class.java)
 
         return repoSearchResult.toStandardSearchResult()
 
@@ -164,7 +164,7 @@ class RemoteAzureDevopsImpl @JvmOverloads constructor(private val azureDevopsUrl
         val response=httpClient.newCall(request).execute()
 
         if(response.isSuccessful){
-            return response.body?.string() ?: ""
+            return response.body.string()
         }
         else{
             throw NoFileFoundException("can't find $fileToFetch in repo $repositoryFullName, in branch $branchName")
@@ -245,7 +245,7 @@ internal class AzureDevopsResponseDecoder {
         }
 
         val writer = StringWriter()
-        IOUtils.copy(response.body?.byteStream(), writer, "UTF-8")
+        IOUtils.copy(response.body.byteStream(), writer, "UTF-8")
         val responseAsString = writer.toString()
 
         return parseRepositoryConfigResponse(responseAsString, response)

--- a/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/remote/RemoteBitBucketImpl.kt
+++ b/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/remote/RemoteBitBucketImpl.kt
@@ -1,10 +1,9 @@
 package com.societegenerale.githubcrawler.remote
 
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
-import com.fasterxml.jackson.module.kotlin.KotlinModule
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.dataformat.yaml.YAMLMapper
+import tools.jackson.module.kotlin.KotlinModule
+import tools.jackson.module.kotlin.jacksonObjectMapper
 import com.societegenerale.githubcrawler.RepositoryConfig
 import com.societegenerale.githubcrawler.model.*
 import com.societegenerale.githubcrawler.model.Author
@@ -23,12 +22,9 @@ import feign.gson.GsonEncoder
 import feign.httpclient.ApacheHttpClient
 import feign.slf4j.Slf4jLogger
 import org.slf4j.LoggerFactory
-import org.springframework.boot.autoconfigure.http.HttpMessageConverters
-import org.springframework.cloud.openfeign.support.ResponseEntityDecoder
-import org.springframework.cloud.openfeign.support.SpringDecoder
 import org.springframework.http.HttpStatus
-import org.springframework.http.MediaType
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
+import tools.jackson.core.JacksonException
+
 import java.io.IOException
 import java.lang.reflect.Type
 import java.util.*
@@ -57,8 +53,6 @@ class RemoteBitBucketImpl @JvmOverloads constructor(
 
 
     val log = LoggerFactory.getLogger(this.javaClass)
-
-    private val objectMapper = jacksonObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
 
     override fun validateRemoteConfig(organizationName: String) {
         //TODO("Not yet implemented")
@@ -236,12 +230,9 @@ private interface InternalBitBucketClient {
 internal class BitBucketResponseDecoder : Decoder {
     val log = LoggerFactory.getLogger(this.javaClass)
 
-    val repoConfigMapper = ObjectMapper(YAMLFactory())
-
-    init {
-        repoConfigMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-        repoConfigMapper.registerModule(KotlinModule.Builder().build())
-    }
+    val repoConfigMapper: YAMLMapper = YAMLMapper.builder()
+        .addModule(KotlinModule.Builder().build())
+        .build()
 
     fun decodeRepoConfig(response: String): RepositoryConfig {
 
@@ -263,19 +254,22 @@ internal class BitBucketResponseDecoder : Decoder {
 
             log.debug("Decoding a successful response...")
 
-            if (type.typeName == MediaType.TEXT_PLAIN_VALUE) {
+            if (type == String::class.java) {
 
                 log.debug("\t ... as a String")
 
-                return response.body().toString()
+                return response.body().asReader(Charsets.UTF_8).use { it.readText() }
             }
 
             log.debug("\t ... as a " + type.typeName)
 
-            val jacksonConverter =
-                MappingJackson2HttpMessageConverter(ObjectMapper().registerModule(KotlinModule.Builder().build()))
-            val objectFactory = { HttpMessageConverters(jacksonConverter) }
-            return ResponseEntityDecoder(SpringDecoder(objectFactory)).decode(response, type)
+            val jsonMapper = JsonMapper.builder()
+                .addModule(KotlinModule.Builder().build())
+                .build()
+
+            response.body().asInputStream().use { input ->
+                return jsonMapper.readValue(input, jsonMapper.constructType(type))
+            }
 
         }
     }
@@ -287,7 +281,7 @@ internal class BitBucketResponseDecoder : Decoder {
 
         try {
             return repoConfigMapper.readValue(responseAsString, RepositoryConfig::class.java)
-        } catch (e: IOException) {
+        } catch (e: JacksonException) {
             throw Repository.RepoConfigException(
                 HttpStatus.BAD_REQUEST,
                 "unable to parse config for repo - content : \"" + responseAsString + "\"",

--- a/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/remote/RemoteBitBucketImpl.kt
+++ b/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/remote/RemoteBitBucketImpl.kt
@@ -45,7 +45,7 @@ class RemoteBitBucketImpl @JvmOverloads constructor(
         .client(ApacheHttpClient())
         .encoder(GsonEncoder())
         .decoder(BitBucketResponseDecoder())
-        .decode404()
+        .dismiss404()
         .requestInterceptor(BitBucketOauthTokenSetter(apiKey))
         .logger(Slf4jLogger(RemoteBitBucketImpl::class.java))
         .logLevel(Logger.Level.FULL)

--- a/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/remote/RemoteGitHubImpl.kt
+++ b/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/remote/RemoteGitHubImpl.kt
@@ -56,7 +56,7 @@ class RemoteGitHubImpl @JvmOverloads constructor(
         .encoder(GsonEncoder())
         .decoder(GitHubResponseDecoder())
         .errorDecoder(GiHubErrorDecoder())
-        .decode404()
+        .dismiss404()
         .requestInterceptor(GitHubOauthTokenSetter(apiKey))
         .logger(Slf4jLogger(RemoteGitHubImpl::class.java))
         .logLevel(Logger.Level.FULL)
@@ -170,15 +170,7 @@ class RemoteGitHubImpl @JvmOverloads constructor(
     private fun extractRepositories(response: Response): Set<Repository> {
 
         try {
-
-            val body = response.body
-
-            if (body != null) {
-                return objectMapper.readValue(body.string())
-            } else {
-                log.warn("response is null : {}", response)
-                return emptySet()
-            }
+            return objectMapper.readValue(response.body.string())
         } catch (e: JacksonException) {
             throw NoReachableRepositories("not able to parse response", e)
         }
@@ -233,7 +225,7 @@ class RemoteGitHubImpl @JvmOverloads constructor(
 
         val response = httpClient.newCall(request).execute()
 
-        val responseAsString=response.body?.string()
+        val responseAsString=response.body.string()
         log.info("response : "+responseAsString)
 
         return try {
@@ -271,7 +263,7 @@ class RemoteGitHubImpl @JvmOverloads constructor(
         val response = httpClient.newCall(request).execute()
 
 
-        return response.body?.string() ?: ""
+        return response.body.string()
 
     }
 
@@ -393,7 +385,7 @@ internal class GitHubResponseDecoder : Decoder {
     fun decodeRepoConfig(response: Response): RepositoryConfig {
 
         val writer = StringWriter()
-        IOUtils.copy(response.body?.byteStream(), writer, "UTF-8")
+        IOUtils.copy(response.body.byteStream(), writer, "UTF-8")
         val responseAsString = writer.toString()
 
         return parseRepositoryConfigResponse(responseAsString, response)

--- a/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/remote/RemoteGitHubImpl.kt
+++ b/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/remote/RemoteGitHubImpl.kt
@@ -1,13 +1,10 @@
 package com.societegenerale.githubcrawler.remote
 
-import com.fasterxml.jackson.core.JsonParseException
-import com.fasterxml.jackson.core.JsonProcessingException
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
-import com.fasterxml.jackson.module.kotlin.KotlinModule
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.dataformat.yaml.YAMLMapper
+import tools.jackson.module.kotlin.KotlinModule
+import tools.jackson.module.kotlin.jacksonObjectMapper
+import tools.jackson.module.kotlin.readValue
 import com.societegenerale.githubcrawler.RepositoryConfig
 import com.societegenerale.githubcrawler.model.*
 import com.societegenerale.githubcrawler.model.commit.Commit
@@ -26,12 +23,10 @@ import okhttp3.OkHttpClient
 import okhttp3.Response
 import org.apache.commons.io.IOUtils
 import org.slf4j.LoggerFactory
-import org.springframework.boot.autoconfigure.http.HttpMessageConverters
-import org.springframework.cloud.openfeign.support.ResponseEntityDecoder
-import org.springframework.cloud.openfeign.support.SpringDecoder
 import org.springframework.http.HttpStatus
-import org.springframework.http.MediaType
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
+import tools.jackson.core.JacksonException
+import tools.jackson.core.exc.StreamReadException
+
 import java.io.IOException
 import java.io.StringWriter
 import java.lang.reflect.Type
@@ -72,7 +67,7 @@ class RemoteGitHubImpl @JvmOverloads constructor(
 
     val log = LoggerFactory.getLogger(this.javaClass)
 
-    private val objectMapper = jacksonObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+    private val objectMapper = jacksonObjectMapper()
 
     @Throws(NoReachableRepositories::class)
     override fun validateRemoteConfig(organizationName: String) {
@@ -81,7 +76,7 @@ class RemoteGitHubImpl @JvmOverloads constructor(
 
         try {
             extractRepositories(response)
-        } catch (e: JsonProcessingException) {
+        } catch (e: JacksonException) {
             throw NoReachableRepositories("not able to parse response : ${response.body}", e)
         }
 
@@ -184,7 +179,7 @@ class RemoteGitHubImpl @JvmOverloads constructor(
                 log.warn("response is null : {}", response)
                 return emptySet()
             }
-        } catch (e: JsonProcessingException) {
+        } catch (e: JacksonException) {
             throw NoReachableRepositories("not able to parse response", e)
         }
     }
@@ -244,7 +239,7 @@ class RemoteGitHubImpl @JvmOverloads constructor(
         return try {
             objectMapper.readValue(responseAsString, SearchResult::class.java)
         }
-        catch(e : JsonParseException){
+        catch(e : StreamReadException){
             log.warn("parsing error",e)
             SearchResult(0, emptyList())
         }
@@ -391,12 +386,9 @@ internal class GiHubErrorDecoder : ErrorDecoder {
 internal class GitHubResponseDecoder : Decoder {
     val log = LoggerFactory.getLogger(this.javaClass)
 
-    val repoConfigMapper = ObjectMapper(YAMLFactory())
-
-    init {
-        repoConfigMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-        repoConfigMapper.registerModule(KotlinModule.Builder().build())
-    }
+    val repoConfigMapper: YAMLMapper = YAMLMapper.builder()
+        .addModule(KotlinModule.Builder().build())
+        .build()
 
     fun decodeRepoConfig(response: Response): RepositoryConfig {
 
@@ -423,18 +415,22 @@ internal class GitHubResponseDecoder : Decoder {
 
             log.debug("Decoding a successful response...")
 
-            if (type.typeName == MediaType.TEXT_PLAIN_VALUE) {
+            if (type == String::class.java) {
 
                 log.debug("\t ... as a String")
 
-                return response.body().toString()
+                return response.body().asReader(Charsets.UTF_8).use { it.readText() }
             }
 
             log.debug("\t ... as a " + type.typeName)
 
-            val jacksonConverter = MappingJackson2HttpMessageConverter(ObjectMapper().registerModule(KotlinModule.Builder().build()))
-            val objectFactory = { HttpMessageConverters(jacksonConverter) }
-            return ResponseEntityDecoder(SpringDecoder(objectFactory)).decode(response, type)
+            val jsonMapper = JsonMapper.builder()
+                .addModule(KotlinModule.Builder().build())
+                .build()
+
+            response.body().asInputStream().use { input ->
+                return jsonMapper.readValue(input, jsonMapper.constructType(type))
+            }
 
         }
     }
@@ -446,7 +442,7 @@ internal class GitHubResponseDecoder : Decoder {
 
         try {
             return repoConfigMapper.readValue(responseAsString, RepositoryConfig::class.java)
-        } catch (e: IOException) {
+        } catch (e: JacksonException) {
             throw Repository.RepoConfigException(HttpStatus.BAD_REQUEST,"unable to parse config for repo - content : \"" + response.body + "\"", e)
         }
     }

--- a/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/remote/RemoteGitLabImpl.kt
+++ b/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/remote/RemoteGitLabImpl.kt
@@ -53,7 +53,7 @@ class RemoteGitLabImpl constructor(
         .encoder(GsonEncoder())
         .decoder(GitLabResponseDecoder())
         .errorDecoder(GiLabErrorDecoder())
-        .decode404()
+        .dismiss404()
         .requestInterceptor(GitLabPrivateTokenSetter(privateToken))
         .logger(Slf4jLogger(RemoteGitLabImpl::class.java))
         .logLevel(Logger.Level.FULL)
@@ -102,7 +102,7 @@ class RemoteGitLabImpl constructor(
 
         val httpResponse=httpClient.newCall(request).execute()
 
-        val gitlabSearchResult : List<GitLabSearchResultItem> = objectMapper.readValue(httpResponse.body!!.string())
+        val gitlabSearchResult : List<GitLabSearchResultItem> = objectMapper.readValue(httpResponse.body.string())
 
         return SearchResult(gitlabSearchResult.size,gitlabSearchResult.map{ it -> it.toSearchResultItem()})
 
@@ -181,7 +181,7 @@ class RemoteGitLabImpl constructor(
             throw NoReachableRepositories("GET call to ${fetchFileUrl} wasn't successful. Code : ${response.code}, Message : ${response.message}")
         }
 
-        return response.body!!.string()
+        return response.body.string()
     }
 
     @Throws(NoReachableRepositories::class)

--- a/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/remote/RemoteGitLabImpl.kt
+++ b/github-crawler-core/src/main/kotlin/com/societegenerale/githubcrawler/remote/RemoteGitLabImpl.kt
@@ -1,12 +1,11 @@
 package com.societegenerale.githubcrawler.remote
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
-import com.fasterxml.jackson.module.kotlin.KotlinModule
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.dataformat.yaml.YAMLMapper
+import tools.jackson.module.kotlin.KotlinModule
+import tools.jackson.module.kotlin.jacksonObjectMapper
+import tools.jackson.module.kotlin.readValue
 import com.societegenerale.githubcrawler.RepositoryConfig
 import com.societegenerale.githubcrawler.model.*
 import com.societegenerale.githubcrawler.model.commit.Commit
@@ -23,12 +22,9 @@ import feign.httpclient.ApacheHttpClient
 import feign.slf4j.Slf4jLogger
 import okhttp3.OkHttpClient
 import org.slf4j.LoggerFactory
-import org.springframework.boot.autoconfigure.http.HttpMessageConverters
-import org.springframework.cloud.openfeign.support.ResponseEntityDecoder
-import org.springframework.cloud.openfeign.support.SpringDecoder
 import org.springframework.http.HttpStatus
-import org.springframework.http.MediaType
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
+import tools.jackson.core.JacksonException
+
 import java.io.IOException
 import java.lang.reflect.Type
 import java.util.*
@@ -71,7 +67,7 @@ class RemoteGitLabImpl constructor(
 
     val log = LoggerFactory.getLogger(this.javaClass)
 
-    private val objectMapper = jacksonObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+    private val objectMapper = jacksonObjectMapper()
 
     override fun fetchRepoConfig(repositoryFullName: String, defaultBranch: String): RepositoryConfig {
 
@@ -268,12 +264,9 @@ data class GitLabRepository (val id : Int,val web_url : String, val path : Strin
 internal class GitLabResponseDecoder : Decoder {
     val log = LoggerFactory.getLogger(this.javaClass)
 
-    val repoConfigMapper = ObjectMapper(YAMLFactory())
-
-    init {
-        repoConfigMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-        repoConfigMapper.registerModule(KotlinModule())
-    }
+    val repoConfigMapper: YAMLMapper = YAMLMapper.builder()
+        .addModule(KotlinModule.Builder().build())
+        .build()
 
     @Throws(IOException::class)
     override fun decode(response: Response, type: Type): Any {
@@ -290,18 +283,22 @@ internal class GitLabResponseDecoder : Decoder {
 
             log.debug("Decoding a successful response...")
 
-            if (type.typeName == MediaType.TEXT_PLAIN_VALUE) {
+            if (type == String::class.java) {
 
                 log.debug("\t ... as a String")
 
-                return response.body().toString()
+                return response.body().asReader(Charsets.UTF_8).use { it.readText() }
             }
 
             log.debug("\t ... as a " + type.typeName)
 
-            val jacksonConverter = MappingJackson2HttpMessageConverter(ObjectMapper().registerModule(KotlinModule.Builder().build()))
-            val objectFactory = { HttpMessageConverters(jacksonConverter) }
-            return ResponseEntityDecoder(SpringDecoder(objectFactory)).decode(response, type)
+            val jsonMapper = JsonMapper.builder()
+                .addModule(KotlinModule.Builder().build())
+                .build()
+
+            response.body().asInputStream().use { input ->
+                return jsonMapper.readValue(input, jsonMapper.constructType(type))
+            }
 
         }
     }
@@ -313,7 +310,7 @@ internal class GitLabResponseDecoder : Decoder {
 
         try {
             return repoConfigMapper.readValue(responseAsString, RepositoryConfig::class.java)
-        } catch (e: IOException) {
+        } catch (e: JacksonException) {
             throw Repository.RepoConfigException(HttpStatus.BAD_REQUEST,"unable to parse config for repo - content : \"$responseAsString\"", e)
         }
     }

--- a/github-crawler-core/src/test/java/com/societegenerale/githubcrawler/ConfigParserTest.java
+++ b/github-crawler-core/src/test/java/com/societegenerale/githubcrawler/ConfigParserTest.java
@@ -2,9 +2,10 @@ package com.societegenerale.githubcrawler;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.fasterxml.jackson.module.kotlin.KotlinModule;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.dataformat.yaml.YAMLMapper;
+import tools.jackson.module.kotlin.KotlinModule;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
@@ -14,7 +15,9 @@ import org.springframework.util.StreamUtils;
 
 class ConfigParserTest {
 
-    ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+    ObjectMapper mapper = YAMLMapper.builder()
+        .addModule(new KotlinModule.Builder().build())
+        .build();
 
     @Test
     void canParseSimpleYamlConfig() throws IOException {
@@ -32,15 +35,13 @@ class ConfigParserTest {
         InputStream is = getClass().getClassLoader().getResourceAsStream("sampleRepoConfig.yaml");
         String configToParse = StreamUtils.copyToString(is, Charset.forName("UTF-8"));
 
-        mapper.registerModule(new KotlinModule());
-
         RepositoryConfig parsedRepositoryConfig = mapper.readValue(configToParse, RepositoryConfig.class);
 
         assertThat(parsedRepositoryConfig).isNotNull();
         assertThat(parsedRepositoryConfig.getExcluded()).isFalse();
         assertThat(parsedRepositoryConfig.getFilesToParse()).hasSize(1);
 
-        FileToParse firstFile = parsedRepositoryConfig.getFilesToParse().get(0);
+        FileToParse firstFile = parsedRepositoryConfig.getFilesToParse().getFirst();
         assertThat(firstFile.getRedirectTo()).isEqualTo("moduleWhereDockerFileIs/Dockerfile");
         assertThat(firstFile.getName()).isEqualTo("Dockerfile");
     }
@@ -50,7 +51,7 @@ class ConfigParserTest {
 
         String configToParse = "{\"excluded\": true}";
 
-        ObjectMapper mapper = new ObjectMapper();
+        ObjectMapper mapper = new JsonMapper();
 
         RepositoryConfig parsedRepositoryConfig = mapper.readValue(configToParse, RepositoryConfig.class);
 

--- a/github-crawler-core/src/test/java/com/societegenerale/githubcrawler/GitHubCrawlerTest.kt
+++ b/github-crawler-core/src/test/java/com/societegenerale/githubcrawler/GitHubCrawlerTest.kt
@@ -1,13 +1,13 @@
 package com.societegenerale.githubcrawler
 
 import com.google.common.collect.ImmutableList
-import com.jayway.awaitility.Awaitility.await
 import com.societegenerale.githubcrawler.model.Repository
 import com.societegenerale.githubcrawler.output.GitHubCrawlerOutput
 import com.societegenerale.githubcrawler.parsers.SimpleFilePathParser
 import com.societegenerale.githubcrawler.remote.RemoteSourceControl
 
 import org.assertj.core.api.Assertions.assertThat
+import org.awaitility.Awaitility
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -142,8 +142,8 @@ class GitHubCrawlerTest {
 
         gitHubCrawler.crawl()
 
-        await().atMost(2, java.util.concurrent.TimeUnit.SECONDS)
-                .until({ assertThat(output.analyzedRepositories.values).hasSize(nbExpectedRecords) })
+        Awaitility.await().atMost(2, java.util.concurrent.TimeUnit.SECONDS)
+                .untilAsserted { assertThat(output.analyzedRepositories.values).hasSize(nbExpectedRecords) }
 
         return output.analyzedRepositories
 

--- a/github-crawler-core/src/test/java/com/societegenerale/githubcrawler/output/FileOutputTest.kt
+++ b/github-crawler-core/src/test/java/com/societegenerale/githubcrawler/output/FileOutputTest.kt
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver
 import java.nio.file.Files
-import java.nio.file.Paths
+import java.nio.file.Path
 import java.util.*
 
 
@@ -22,7 +22,7 @@ class FileOutputTest{
         val resources = resolver.getResources("file:target/somePrfix*.txt")
 
         for(existingFile in resources){
-            val fileToDeletePath = Paths.get(existingFile.uri)
+            val fileToDeletePath = Path.of(existingFile.uri)
             Files.delete(fileToDeletePath)
         }
 
@@ -61,7 +61,7 @@ class FileOutputTest{
 
         assertThat(resources).hasSize(1)
 
-        val lines=Files.readAllLines(Paths.get(resources[0].uri))
+        val lines=Files.readAllLines(Path.of(resources[0].uri))
 
         assertThat(lines).hasSize(3)
 

--- a/github-crawler-core/src/test/java/com/societegenerale/githubcrawler/output/HttpOutputTest.kt
+++ b/github-crawler-core/src/test/java/com/societegenerale/githubcrawler/output/HttpOutputTest.kt
@@ -37,6 +37,7 @@ class HttpOutputTest {
   inline fun <reified T : Any> argumentCaptor() = ArgumentCaptor.forClass(T::class.java)
 
   @Test
+  @Suppress("UNCHECKED_CAST")
   fun shouldLogResponseBodyWhenErrorDuringPost() {
     //Mock logging infra
     val root = LoggerFactory.getLogger(ch.qos.logback.classic.Logger.ROOT_LOGGER_NAME) as ch.qos.logback.classic.Logger

--- a/github-crawler-core/src/test/java/com/societegenerale/githubcrawler/repoTaskToPerform/PathsForHitsOnRepoSearchTest.kt
+++ b/github-crawler-core/src/test/java/com/societegenerale/githubcrawler/repoTaskToPerform/PathsForHitsOnRepoSearchTest.kt
@@ -49,6 +49,7 @@ class PathsForHitsOnRepoSearchTest {
 
 
     @Test
+    @Suppress("UNCHECKED_CAST")
     fun shouldYield_NotFound_WhenNoMatch() {
 
         `when`(mockRemoteGithub.fetchCodeSearchResult(repoToSearch.fullName, "someSearch"))

--- a/github-crawler-core/src/test/resources/sample_invalid_yamlfile.yml
+++ b/github-crawler-core/src/test/resources/sample_invalid_yamlfile.yml
@@ -19,7 +19,7 @@ boolean.property: true
 
 ---
 spring:
-  profiles: aProfile
+  config.activate.on-profile: aProfile
 server:
   ssl:
     key-store: hello

--- a/github-crawler-core/src/test/resources/sample_yamlfile.yml
+++ b/github-crawler-core/src/test/resources/sample_yamlfile.yml
@@ -24,7 +24,7 @@ boolean.property: true
 
 ---
 spring:
-  profiles: aProfile
+  config.activate.on-profile: aProfile
 server:
   ssl:
     key-store: hello

--- a/github-crawler-starter/pom.xml
+++ b/github-crawler-starter/pom.xml
@@ -1,49 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>github-crawler-starter</artifactId>
+  <packaging>jar</packaging>
+  <name>github-crawler-starter</name>
+  <parent>
     <groupId>com.societegenerale.github-crawler</groupId>
-    <artifactId>github-crawler-starter</artifactId>
+    <artifactId>github-crawler-parent</artifactId>
     <version>2.2.1-SNAPSHOT</version>
-    <packaging>jar</packaging>
-
-    <name>github-crawler-starter</name>
-
-    <parent>
-        <groupId>com.societegenerale.github-crawler</groupId>
-        <artifactId>github-crawler-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
-    </parent>
-
-    <dependencies>
-
-        <dependency>
-            <groupId>com.societegenerale.github-crawler</groupId>
-            <artifactId>github-crawler-autoconfigure</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
-
-    </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-
-                <!-- This is required so that we have more flexibility :
-
-                - the -exec jar can be used directly from command line
-                - the regular jar can be used as a dependency in projects that need it
-
-                -->
-
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
-                <configuration>
-                    <mainClass>com.societegenerale.githubcrawler.GitHubCrawlerApplication</mainClass>
-                    <classifier>exec</classifier>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
+  </parent>
+  <dependencies>
+    <dependency>
+      <groupId>com.societegenerale.github-crawler</groupId>
+      <artifactId>github-crawler-autoconfigure</artifactId>
+      <version>${project.parent.version}</version>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <!-- This is required so that we have more flexibility :
+        - the -exec jar can be used directly from command line
+        - the regular jar can be used as a dependency in projects that need it
+        -->
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <configuration>
+          <mainClass>com.societegenerale.githubcrawler.GitHubCrawlerApplication</mainClass>
+          <classifier>exec</classifier>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/github-crawler-starter/pom.xml
+++ b/github-crawler-starter/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>com.societegenerale.github-crawler</groupId>
     <artifactId>github-crawler-parent</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
   <dependencies>
     <dependency>

--- a/github-crawler-starter/pom.xml
+++ b/github-crawler-starter/pom.xml
@@ -26,6 +26,7 @@
         -->
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${spring-boot-maven-plugin.version}</version>
         <configuration>
           <mainClass>com.societegenerale.githubcrawler.GitHubCrawlerApplication</mainClass>
           <classifier>exec</classifier>

--- a/github-crawler-starter/pom.xml
+++ b/github-crawler-starter/pom.xml
@@ -31,6 +31,13 @@
           <mainClass>com.societegenerale.githubcrawler.GitHubCrawlerApplication</mainClass>
           <classifier>exec</classifier>
         </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/github-crawler-starter/pom.xml
+++ b/github-crawler-starter/pom.xml
@@ -15,7 +15,6 @@
     <dependency>
       <groupId>com.societegenerale.github-crawler</groupId>
       <artifactId>github-crawler-autoconfigure</artifactId>
-      <version>${project.parent.version}</version>
     </dependency>
   </dependencies>
   <build>

--- a/github-crawler-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/github-crawler-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.societegenerale.githubcrawler.config.GitHubCrawlerAutoConfiguration

--- a/pom.xml
+++ b/pom.xml
@@ -1,429 +1,367 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-
-    <groupId>com.societegenerale.github-crawler</groupId>
-    <artifactId>github-crawler-parent</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
-    <packaging>pom</packaging>
-
-    <name>github-crawler</name>
-
-    <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.5</version>
-        <relativePath /> <!-- lookup parent from repository -->
-    </parent>
-
-    <modules>
-        <module>github-crawler-core</module>
-        <module>github-crawler-autoconfigure</module>
-        <module>github-crawler-starter</module>
-    </modules>
-
-
-    <licenses>
-        <license>
-            <name>Apache 2</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
-
-    <issueManagement>
-        <url>https://github.com/societe-generale/github-crawler/issues</url>
-        <system>GitHub</system>
-    </issueManagement>
-
-    <scm>
-        <url>https://github.com/societe-generale/github-crawler</url>
-        <connection>scm:git:git@github.com:societe-generale/github-crawler.git</connection>
-        <developerConnection>scm:git:git@github.com:societe-generale/github-crawler.git</developerConnection>
-        <tag>HEAD</tag>
-    </scm>
-
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
-
-
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <java.version>11</java.version>
-
-
-        <kotlin.version>1.8.10</kotlin.version>
-        <gson.version>2.10</gson.version>
-        <jacoco.version>0.8.8</jacoco.version>
-
-
-    </properties>
-
-
-    <pluginRepositories>
-        <pluginRepository>
-            <id>jcenter</id>
-            <name>JCenter</name>
-            <url>https://jcenter.bintray.com/</url>
-        </pluginRepository>
-    </pluginRepositories>
-
-    <dependencyManagement>
-        <dependencies>
-
-            <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-openfeign-dependencies</artifactId>
-            <version>3.1.5</version>
-            <type>pom</type>
-            <scope>import</scope>
-            </dependency>
-
-        </dependencies>
-
-    </dependencyManagement>
-
-
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.societegenerale.github-crawler</groupId>
+  <artifactId>github-crawler-parent</artifactId>
+  <version>2.2.1-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <name>github-crawler</name>
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>2.7.5</version>
+    <relativePath/> <!-- lookup parent from repository -->
+  </parent>
+  <modules>
+    <module>github-crawler-core</module>
+    <module>github-crawler-autoconfigure</module>
+    <module>github-crawler-starter</module>
+  </modules>
+  <licenses>
+    <license>
+      <name>Apache 2</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <issueManagement>
+    <url>https://github.com/societe-generale/github-crawler/issues</url>
+    <system>GitHub</system>
+  </issueManagement>
+  <scm>
+    <url>https://github.com/societe-generale/github-crawler</url>
+    <connection>scm:git:git@github.com:societe-generale/github-crawler.git</connection>
+    <developerConnection>scm:git:git@github.com:societe-generale/github-crawler.git
+    </developerConnection>
+    <tag>HEAD</tag>
+  </scm>
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+    <repository>
+      <id>ossrh</id>
+      <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+  </distributionManagement>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <java.version>11</java.version>
+    <kotlin.version>1.8.10</kotlin.version>
+    <gson.version>2.10</gson.version>
+    <jacoco.version>0.8.8</jacoco.version>
+  </properties>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>jcenter</id>
+      <name>JCenter</name>
+      <url>https://jcenter.bintray.com/</url>
+    </pluginRepository>
+  </pluginRepositories>
+  <dependencyManagement>
     <dependencies>
-
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>31.1-jre</version>
-        </dependency>
-
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.vaadin.external.google</groupId>
-                    <artifactId>android-json</artifactId>
-                </exclusion>
-
-                <exclusion>
-                    <groupId>ch.qos.logback</groupId>
-                    <artifactId>logback-classic</artifactId>
-                </exclusion>
-
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib-jdk8</artifactId>
-            <version>${kotlin.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-reflect</artifactId>
-            <version>${kotlin.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-annotations-jvm</artifactId>
-            <version>${kotlin.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-test</artifactId>
-            <version>${kotlin.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.dom4j</groupId>
-            <artifactId>dom4j</artifactId>
-            <version>2.1.3</version>
-        </dependency>
-
-        <!-- see https://github.com/dom4j/dom4j/issues/24
-
-        Jaxen is declared as an optional dependency in dom4j 2.1.1, as a workaround.
-        Once this is fixed, we shouldn't have to declare jaxen ourselves, it should be pulled transitively.
-
-        -->
-        <dependency>
-            <groupId>jaxen</groupId>
-            <artifactId>jaxen</artifactId>
-            <version>1.1.6</version>
-        </dependency>
-
-
+      <dependency>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-openfeign-dependencies</artifactId>
+        <version>3.1.5</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
-
-    <build>
-
-        <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
-
+  </dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>31.1-jre</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.vaadin.external.google</groupId>
+          <artifactId>android-json</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-classic</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib-jdk8</artifactId>
+      <version>${kotlin.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-reflect</artifactId>
+      <version>${kotlin.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-annotations-jvm</artifactId>
+      <version>${kotlin.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-test</artifactId>
+      <version>${kotlin.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.dom4j</groupId>
+      <artifactId>dom4j</artifactId>
+      <version>2.1.3</version>
+    </dependency><!-- see https://github.com/dom4j/dom4j/issues/24 Jaxen is declared as an optional dependency in dom4j 2.1.1, as a workaround. Once this is fixed, we shouldn't have to declare jaxen ourselves, it should be pulled transitively. -->
+    <dependency>
+      <groupId>jaxen</groupId>
+      <artifactId>jaxen</artifactId>
+      <version>1.1.6</version>
+    </dependency>
+  </dependencies>
+  <build>
+    <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
+    <plugins>
+      <plugin>
+        <artifactId>kotlin-maven-plugin</artifactId>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <version>${kotlin.version}</version>
+        <executions>
+          <execution>
+            <id>compile</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <sourceDirs>
+                <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
+              </sourceDirs>
+            </configuration>
+          </execution>
+          <execution>
+            <id>test-compile</id>
+            <phase>test-compile</phase>
+            <goals>
+              <goal>test-compile</goal>
+            </goals>
+            <configuration>
+              <sourceDirs>
+                <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
+                <sourceDir>${project.basedir}/src/test/java</sourceDir>
+              </sourceDirs>
+            </configuration>
+          </execution>
+        </executions>
+        <configuration>
+          <jvmTarget>1.8</jvmTarget>
+          <args>
+            <arg>-Xjvm-default=all-compatibility</arg>
+          </args>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.10.1</version>
+        <executions><!-- Replacing default-compile as it is treated specially by maven -->
+          <execution>
+            <id>default-compile</id>
+            <phase>none</phase>
+          </execution><!-- Replacing default-testCompile as it is treated specially by maven -->
+          <execution>
+            <id>default-testCompile</id>
+            <phase>none</phase>
+          </execution>
+          <execution>
+            <id>java-compile</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>java-test-compile</id>
+            <phase>test-compile</phase>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-release-plugin</artifactId>
+        <version>2.5.3</version>
+        <configuration>
+          <stagingRepository>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2
+          </stagingRepository>
+          <tagNameFormat>github_crawler_@{project.version}</tagNameFormat>
+          <localCheckout>true</localCheckout>
+          <autoVersionSubmodules>true</autoVersionSubmodules>
+          <pushChanges>false</pushChanges>
+          <useReleaseProfile>false</useReleaseProfile>
+          <releaseProfiles>makeRelease</releaseProfiles>
+          <mavenExecutorId>forked-path</mavenExecutorId>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration><!-- Sets the VM argument line used when unit tests are run. -->
+          <argLine>${surefireArgLine}</argLine>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+            <configuration>
+              <argLine>${failsafeArgLine}</argLine>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>${jacoco.version}</version>
+        <executions>
+          <execution>
+            <id>pre-unit-tests</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+            <configuration>
+              <propertyName>surefireArgLine</propertyName>
+            </configuration>
+          </execution>
+          <execution>
+            <id>pre-integration-tests</id>
+            <goals>
+              <goal>prepare-agent-integration</goal>
+            </goals>
+            <configuration>
+              <propertyName>failsafeArgLine</propertyName>
+            </configuration>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>test</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.eluder.coveralls</groupId>
+        <artifactId>coveralls-maven-plugin</artifactId>
+        <version>4.3.0</version>
+        <dependencies>
+          <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <version>1.6.8</version>
+        <extensions>true</extensions>
+        <configuration>
+          <serverId>ossrh</serverId>
+          <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
+          <autoReleaseAfterClose>true</autoReleaseAfterClose>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>2.8.2</version>
+      </plugin>
+    </plugins>
+  </build>
+  <profiles>
+    <profile>
+      <id>makeRelease</id>
+      <build>
         <plugins>
-
-            <plugin>
-                <artifactId>kotlin-maven-plugin</artifactId>
-                <groupId>org.jetbrains.kotlin</groupId>
-                <version>${kotlin.version}</version>
-                <executions>
-                    <execution>
-                        <id>compile</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>compile</goal>
-                        </goals>
-                        <configuration>
-                            <sourceDirs>
-                                <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
-                            </sourceDirs>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>test-compile</id>
-                        <phase>test-compile</phase>
-                        <goals>
-                            <goal>test-compile</goal>
-                        </goals>
-                        <configuration>
-                            <sourceDirs>
-                                <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
-                                <sourceDir>${project.basedir}/src/test/java</sourceDir>
-                            </sourceDirs>
-                        </configuration>
-                    </execution>
-                </executions>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <version>3.0.0</version>
+            <executions>
+              <execution>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>add-source</goal>
+                </goals>
                 <configuration>
-                    <jvmTarget>1.8</jvmTarget>
-                    <args>
-                        <arg>-Xjvm-default=all-compatibility</arg>
-                    </args>
+                  <sources>
+                    <source>${project.basedir}/src/main/kotlin</source>
+                  </sources>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.1</version>
-                <executions>
-                    <!-- Replacing default-compile as it is treated specially by maven -->
-                    <execution>
-                        <id>default-compile</id>
-                        <phase>none</phase>
-                    </execution>
-                    <!-- Replacing default-testCompile as it is treated specially by maven -->
-                    <execution>
-                        <id>default-testCompile</id>
-                        <phase>none</phase>
-                    </execution>
-                    <execution>
-                        <id>java-compile</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>compile</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>java-test-compile</id>
-                        <phase>test-compile</phase>
-                        <goals>
-                            <goal>testCompile</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.3</version>
-                <configuration>
-                    <stagingRepository>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2</stagingRepository>
-                    <tagNameFormat>github_crawler_@{project.version}</tagNameFormat>
-                    <localCheckout>true</localCheckout>
-                    <autoVersionSubmodules>true</autoVersionSubmodules>
-                    <pushChanges>false</pushChanges>
-                    <useReleaseProfile>false</useReleaseProfile>
-                    <releaseProfiles>makeRelease</releaseProfiles>
-                    <mavenExecutorId>forked-path</mavenExecutorId>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-
-                <configuration>
-                    <!-- Sets the VM argument line used when unit tests are run. -->
-                    <argLine>${surefireArgLine}</argLine>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
-                        </goals>
-                        <configuration>
-                            <argLine>${failsafeArgLine}</argLine>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <version>${jacoco.version}</version>
-                <executions>
-                    <execution>
-                        <id>pre-unit-tests</id>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                        <configuration>
-                            <propertyName>surefireArgLine</propertyName>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>pre-integration-tests</id>
-                        <goals>
-                            <goal>prepare-agent-integration</goal>
-                        </goals>
-                        <configuration>
-                            <propertyName>failsafeArgLine</propertyName>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>report</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.eluder.coveralls</groupId>
-                <artifactId>coveralls-maven-plugin</artifactId>
-                <version>4.3.0</version>
-              <dependencies>
-                <dependency>
-                  <groupId>javax.xml.bind</groupId>
-                  <artifactId>jaxb-api</artifactId>
-                  <version>2.3.1</version>
-                </dependency>
-              </dependencies>
-            </plugin>
-
-
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.8</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <version>2.8.2</version>
-            </plugin>
-
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>3.0.1</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.jetbrains.dokka</groupId>
+            <artifactId>dokka-maven-plugin</artifactId>
+            <version>1.6.10</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>javadocJar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>3.0.1</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
         </plugins>
-    </build>
-
-    <profiles>
-        <profile>
-            <id>makeRelease</id>
-
-            <build>
-                <plugins>
-
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>build-helper-maven-plugin</artifactId>
-                        <version>3.0.0</version>
-
-                        <executions>
-                            <execution>
-                                <phase>generate-sources</phase>
-                                <goals>
-                                    <goal>add-source</goal>
-                                </goals>
-                                <configuration>
-                                    <sources>
-                                        <source>${project.basedir}/src/main/kotlin</source>
-                                    </sources>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-source-plugin</artifactId>
-                        <version>3.0.1</version>
-                        <executions>
-                            <execution>
-                                <id>attach-sources</id>
-                                <goals>
-                                    <goal>jar-no-fork</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-
-                    <plugin>
-                        <groupId>org.jetbrains.dokka</groupId>
-                        <artifactId>dokka-maven-plugin</artifactId>
-                        <version>1.6.10</version>
-                        <executions>
-                            <execution>
-                                <id>attach-javadocs</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>javadocJar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.0.1</version>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
-
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -274,12 +274,24 @@
           <mavenExecutorId>forked-path</mavenExecutorId>
         </configuration>
       </plugin>
+      <plugin><!-- Exposes the mockito-core jar path as ${org.mockito:mockito-core:jar}, so it can be loaded as a -javaagent (Mockito no longer self-attaches on recent JDKs). -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>get-mockito-agent-path</id>
+            <goals>
+              <goal>properties</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${maven-surefire-plugin.version}</version>
         <configuration><!-- Sets the VM argument line used when unit tests are run. -->
-          <argLine>${surefireArgLine} --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --add-opens java.base/jdk.internal.reflect=ALL-UNNAMED -Dnet.bytebuddy.experimental=true --sun-misc-unsafe-memory-access=allow</argLine>
+          <argLine>-javaagent:${org.mockito:mockito-core:jar} ${surefireArgLine} --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --add-opens java.base/jdk.internal.reflect=ALL-UNNAMED -Dnet.bytebuddy.experimental=true --sun-misc-unsafe-memory-access=allow</argLine>
         </configuration>
       </plugin>
       <plugin>
@@ -293,7 +305,7 @@
               <goal>verify</goal>
             </goals>
             <configuration>
-              <argLine>${failsafeArgLine} --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --add-opens java.base/jdk.internal.reflect=ALL-UNNAMED -Dnet.bytebuddy.experimental=true --sun-misc-unsafe-memory-access=allow</argLine>
+              <argLine>-javaagent:${org.mockito:mockito-core:jar} ${failsafeArgLine} --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --add-opens java.base/jdk.internal.reflect=ALL-UNNAMED -Dnet.bytebuddy.experimental=true --sun-misc-unsafe-memory-access=allow</argLine>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -8,12 +8,6 @@
   <version>2.2.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>github-crawler</name>
-  <parent>
-    <groupId>org.springframework.boot</groupId>
-    <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.7.5</version>
-    <relativePath/> <!-- lookup parent from repository -->
-  </parent>
   <modules>
     <module>github-crawler-core</module>
     <module>github-crawler-autoconfigure</module>
@@ -22,7 +16,7 @@
   <licenses>
     <license>
       <name>Apache 2</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.html</url>
       <distribution>repo</distribution>
     </license>
   </licenses>
@@ -52,8 +46,16 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>11</java.version>
     <kotlin.version>1.8.10</kotlin.version>
+    <!-- dependencies -->
+    <spring-boot-dependencies.version>2.7.5</spring-boot-dependencies.version>
+    <spring-cloud-openfeign-dependencies.version>3.1.5</spring-cloud-openfeign-dependencies.version>
+    <guava-bom.version>31.1-jre</guava-bom.version>
+    <dom4j.version>2.1.3</dom4j.version>
     <gson.version>2.10</gson.version>
+    <jaxen.version>1.1.6</jaxen.version>
+    <!-- plugins -->
     <jacoco.version>0.8.8</jacoco.version>
+    <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
   </properties>
   <pluginRepositories>
     <pluginRepository>
@@ -65,9 +67,30 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring-boot-dependencies.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.springframework.cloud</groupId>
         <artifactId>spring-cloud-openfeign-dependencies</artifactId>
-        <version>3.1.5</version>
+        <version>${spring-cloud-openfeign-dependencies.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava-bom</artifactId>
+        <version>${guava-bom.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-bom</artifactId>
+        <version>${kotlin.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -77,32 +100,19 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>31.1-jre</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>com.vaadin.external.google</groupId>
-          <artifactId>android-json</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>ch.qos.logback</groupId>
-          <artifactId>logback-classic</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib-jdk8</artifactId>
-      <version>${kotlin.version}</version>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-reflect</artifactId>
-      <version>${kotlin.version}</version>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
@@ -112,18 +122,17 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-test</artifactId>
-      <version>${kotlin.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.dom4j</groupId>
       <artifactId>dom4j</artifactId>
-      <version>2.1.3</version>
+      <version>${dom4j.version}</version>
     </dependency><!-- see https://github.com/dom4j/dom4j/issues/24 Jaxen is declared as an optional dependency in dom4j 2.1.1, as a workaround. Once this is fixed, we shouldn't have to declare jaxen ourselves, it should be pulled transitively. -->
     <dependency>
       <groupId>jaxen</groupId>
       <artifactId>jaxen</artifactId>
-      <version>1.1.6</version>
+      <version>${jaxen.version}</version>
     </dependency>
   </dependencies>
   <build>
@@ -170,7 +179,18 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.10.1</version>
+        <version>${maven-compiler-plugin.version}</version>
+        <configuration>
+          <source>${java.version}</source> <!-- 1.8,1.9,1.10,11,12,13 -->
+          <target>${java.version}</target>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+              <version>1.18.24</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
         <executions><!-- Replacing default-compile as it is treated specially by maven -->
           <execution>
             <id>default-compile</id>

--- a/pom.xml
+++ b/pom.xml
@@ -279,7 +279,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${maven-surefire-plugin.version}</version>
         <configuration><!-- Sets the VM argument line used when unit tests are run. -->
-          <argLine>${surefireArgLine} --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --add-opens java.base/jdk.internal.reflect=ALL-UNNAMED -Dnet.bytebuddy.experimental=true</argLine>
+          <argLine>${surefireArgLine} --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --add-opens java.base/jdk.internal.reflect=ALL-UNNAMED -Dnet.bytebuddy.experimental=true --sun-misc-unsafe-memory-access=allow</argLine>
         </configuration>
       </plugin>
       <plugin>
@@ -293,12 +293,12 @@
               <goal>verify</goal>
             </goals>
             <configuration>
-              <argLine>${failsafeArgLine}</argLine>
+              <argLine>${failsafeArgLine} --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --add-opens java.base/jdk.internal.reflect=ALL-UNNAMED -Dnet.bytebuddy.experimental=true --sun-misc-unsafe-memory-access=allow</argLine>
             </configuration>
           </execution>
         </executions>
         <configuration>
-          <argLine>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --add-opens java.base/jdk.internal.reflect=ALL-UNNAMED -Dnet.bytebuddy.experimental=true</argLine>
+          <argLine>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --add-opens java.base/jdk.internal.reflect=ALL-UNNAMED -Dnet.bytebuddy.experimental=true --sun-misc-unsafe-memory-access=allow</argLine>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
     <jacoco.version>0.8.15</jacoco.version>
     <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
     <maven-surefire-plugin.version>3.5.4</maven-surefire-plugin.version>
+    <spring-boot-maven-plugin.version>4.0.7</spring-boot-maven-plugin.version>
   </properties>
   <pluginRepositories>
     <pluginRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.societegenerale.github-crawler</groupId>
   <artifactId>github-crawler-parent</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>github-crawler</name>
   <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
         <configuration>
           <jvmTarget>${java.version}</jvmTarget>
           <args>
-            <arg>-Xjvm-default=all-compatibility</arg>
+            <arg>-jvm-default=enable</arg>
           </args>
           <compilerPlugins>
             <plugin>spring</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <java.version>25</java.version>
     <kotlin.version>2.4.10</kotlin.version>
     <!-- dependencies -->
-    <spring-boot-dependencies.version>4.0.7</spring-boot-dependencies.version>
+    <spring-boot-dependencies.version>4.1.0</spring-boot-dependencies.version>
     <spring-cloud-openfeign-dependencies.version>5.0.2</spring-cloud-openfeign-dependencies.version>
     <guava-bom.version>31.1-jre</guava-bom.version>
     <dom4j.version>2.1.3</dom4j.version>
@@ -53,7 +53,7 @@
     <jacoco.version>0.8.15</jacoco.version>
     <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
     <maven-surefire-plugin.version>3.5.4</maven-surefire-plugin.version>
-    <spring-boot-maven-plugin.version>4.0.7</spring-boot-maven-plugin.version>
+    <spring-boot-maven-plugin.version>4.1.0</spring-boot-maven-plugin.version>
     <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
     <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
     <central-publishing-maven-plugin.version>0.9.0</central-publishing-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -50,13 +50,17 @@
     <commons-io.version>2.22.0</commons-io.version>
     <json-path.version>3.0.0</json-path.version>
     <!-- plugins -->
-    <jacoco.version>0.8.15</jacoco.version>
+    <jacoco-plugin.version>0.8.15</jacoco-plugin.version>
     <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
-    <maven-surefire-plugin.version>3.5.4</maven-surefire-plugin.version>
+    <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
     <spring-boot-maven-plugin.version>4.1.0</spring-boot-maven-plugin.version>
     <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
     <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
     <central-publishing-maven-plugin.version>0.9.0</central-publishing-maven-plugin.version>
+    <maven-failsafe-plugin.version>3.5.6</maven-failsafe-plugin.version>
+    <maven-dependency-plugin.version>3.11.0</maven-dependency-plugin.version>
+    <coveralls-maven-plugin.version>4.3.0</coveralls-maven-plugin.version>
+    <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
   </properties>
   <pluginRepositories>
     <pluginRepository>
@@ -251,23 +255,10 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-release-plugin</artifactId>
-        <version>2.5.3</version>
-        <configuration>
-          <tagNameFormat>github_crawler_@{project.version}</tagNameFormat>
-          <localCheckout>true</localCheckout>
-          <autoVersionSubmodules>true</autoVersionSubmodules>
-          <pushChanges>false</pushChanges>
-          <useReleaseProfile>false</useReleaseProfile>
-          <releaseProfiles>makeRelease</releaseProfiles>
-          <mavenExecutorId>forked-path</mavenExecutorId>
-        </configuration>
-      </plugin>
       <plugin><!-- Exposes the mockito-core jar path as ${org.mockito:mockito-core:jar}, so it can be loaded as a -javaagent (Mockito no longer self-attaches on recent JDKs). -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
+        <version>${maven-dependency-plugin.version}</version>
         <executions>
           <execution>
             <id>get-mockito-agent-path</id>
@@ -282,13 +273,18 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${maven-surefire-plugin.version}</version>
         <configuration><!-- Sets the VM argument line used when unit tests are run. -->
-          <argLine>-javaagent:${org.mockito:mockito-core:jar} ${surefireArgLine} --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --add-opens java.base/jdk.internal.reflect=ALL-UNNAMED -Dnet.bytebuddy.experimental=true --sun-misc-unsafe-memory-access=allow</argLine>
+          <argLine>-javaagent:${org.mockito:mockito-core:jar} ${surefireArgLine} --add-opens
+            java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED
+            --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --add-opens
+            java.base/jdk.internal.reflect=ALL-UNNAMED -Dnet.bytebuddy.experimental=true
+            --sun-misc-unsafe-memory-access=allow
+          </argLine>
         </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>${maven-surefire-plugin.version}</version>
+        <version>${maven-failsafe-plugin.version}</version>
         <executions>
           <execution>
             <goals>
@@ -296,18 +292,28 @@
               <goal>verify</goal>
             </goals>
             <configuration>
-              <argLine>-javaagent:${org.mockito:mockito-core:jar} ${failsafeArgLine} --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --add-opens java.base/jdk.internal.reflect=ALL-UNNAMED -Dnet.bytebuddy.experimental=true --sun-misc-unsafe-memory-access=allow</argLine>
+              <argLine>-javaagent:${org.mockito:mockito-core:jar} ${failsafeArgLine} --add-opens
+                java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED
+                --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --add-opens
+                java.base/jdk.internal.reflect=ALL-UNNAMED -Dnet.bytebuddy.experimental=true
+                --sun-misc-unsafe-memory-access=allow
+              </argLine>
             </configuration>
           </execution>
         </executions>
         <configuration>
-          <argLine>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --add-opens java.base/jdk.internal.reflect=ALL-UNNAMED -Dnet.bytebuddy.experimental=true --sun-misc-unsafe-memory-access=allow</argLine>
+          <argLine>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens
+            java.base/java.lang.reflect=ALL-UNNAMED --add-opens
+            java.base/jdk.internal.misc=ALL-UNNAMED --add-opens
+            java.base/jdk.internal.reflect=ALL-UNNAMED -Dnet.bytebuddy.experimental=true
+            --sun-misc-unsafe-memory-access=allow
+          </argLine>
         </configuration>
       </plugin>
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>${jacoco.version}</version>
+        <version>${jacoco-plugin.version}</version>
         <executions>
           <execution>
             <id>pre-unit-tests</id>
@@ -339,14 +345,7 @@
       <plugin>
         <groupId>org.eluder.coveralls</groupId>
         <artifactId>coveralls-maven-plugin</artifactId>
-        <version>4.3.0</version>
-        <dependencies>
-          <dependency>
-            <groupId>jakarta.xml.bind</groupId>
-            <artifactId>jakarta.xml.bind-api</artifactId>
-            <version>4.0.5</version>
-          </dependency>
-        </dependencies>
+        <version>${coveralls-maven-plugin.version}</version>
       </plugin>
     </plugins>
   </build>
@@ -358,7 +357,7 @@
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>build-helper-maven-plugin</artifactId>
-            <version>3.0.0</version>
+            <version>${build-helper-maven-plugin.version}</version>
             <executions>
               <execution>
                 <phase>generate-sources</phase>
@@ -420,7 +419,6 @@
               </gpgArguments>
             </configuration>
           </plugin>
-
           <!-- ✨ NEW Sonatype Central Publishing Plugin -->
           <plugin>
             <groupId>org.sonatype.central</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -44,18 +44,25 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <java.version>11</java.version>
-    <kotlin.version>1.8.10</kotlin.version>
+    <java.version>25</java.version>
+    <kotlin.version>2.4.10</kotlin.version>
     <!-- dependencies -->
-    <spring-boot-dependencies.version>2.7.5</spring-boot-dependencies.version>
-    <spring-cloud-openfeign-dependencies.version>3.1.5</spring-cloud-openfeign-dependencies.version>
+    <spring-boot-dependencies.version>4.0.7</spring-boot-dependencies.version>
+    <spring-cloud-openfeign-dependencies.version>5.0.2</spring-cloud-openfeign-dependencies.version>
     <guava-bom.version>31.1-jre</guava-bom.version>
     <dom4j.version>2.1.3</dom4j.version>
     <gson.version>2.10</gson.version>
     <jaxen.version>1.1.6</jaxen.version>
+    <http.version>2.105</http.version>
+    <wiremock-standalone.version>3.13.2</wiremock-standalone.version>
+    <awaitility.version>4.3.0</awaitility.version>
+    <okhttp-bom.version>5.4.0</okhttp-bom.version>
+    <commons-io.version>2.22.0</commons-io.version>
+    <json-path.version>3.0.0</json-path.version>
     <!-- plugins -->
-    <jacoco.version>0.8.8</jacoco.version>
-    <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
+    <jacoco.version>0.8.15</jacoco.version>
+    <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
+    <maven-surefire-plugin.version>3.5.4</maven-surefire-plugin.version>
   </properties>
   <pluginRepositories>
     <pluginRepository>
@@ -66,6 +73,18 @@
   </pluginRepositories>
   <dependencyManagement>
     <dependencies>
+      <!-- Project dependencies -->
+      <dependency>
+        <groupId>com.societegenerale.github-crawler</groupId>
+        <artifactId>github-crawler-core</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.societegenerale.github-crawler</groupId>
+        <artifactId>github-crawler-autoconfigure</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <!-- Boms -->
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
@@ -94,17 +113,25 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>com.squareup.okhttp3</groupId>
+        <artifactId>okhttp-bom</artifactId>
+        <version>${okhttp-bom.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.awaitility</groupId>
+        <artifactId>awaitility</artifactId>
+        <version>${awaitility.version}</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-test</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
@@ -125,6 +152,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.dom4j</groupId>
       <artifactId>dom4j</artifactId>
       <version>${dom4j.version}</version>
@@ -140,6 +172,13 @@
     <plugins>
       <plugin>
         <artifactId>kotlin-maven-plugin</artifactId>
+        <dependencies>
+          <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-maven-allopen</artifactId>
+            <version>${kotlin.version}</version>
+          </dependency>
+        </dependencies>
         <groupId>org.jetbrains.kotlin</groupId>
         <version>${kotlin.version}</version>
         <executions>
@@ -170,26 +209,28 @@
           </execution>
         </executions>
         <configuration>
-          <jvmTarget>1.8</jvmTarget>
+          <jvmTarget>${java.version}</jvmTarget>
           <args>
             <arg>-Xjvm-default=all-compatibility</arg>
           </args>
+          <compilerPlugins>
+            <plugin>spring</plugin>
+          </compilerPlugins>
         </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${maven-compiler-plugin.version}</version>
-        <configuration>
-          <source>${java.version}</source> <!-- 1.8,1.9,1.10,11,12,13 -->
-          <target>${java.version}</target>
+        <configuration> <!-- 1.8,1.9,1.10,11,12,13 -->
           <annotationProcessorPaths>
             <path>
               <groupId>org.projectlombok</groupId>
               <artifactId>lombok</artifactId>
-              <version>1.18.24</version>
+              <version>1.18.46</version>
             </path>
           </annotationProcessorPaths>
+          <release>${java.version}</release>
         </configuration>
         <executions><!-- Replacing default-compile as it is treated specially by maven -->
           <execution>
@@ -235,13 +276,15 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+        <version>${maven-surefire-plugin.version}</version>
         <configuration><!-- Sets the VM argument line used when unit tests are run. -->
-          <argLine>${surefireArgLine}</argLine>
+          <argLine>${surefireArgLine} --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --add-opens java.base/jdk.internal.reflect=ALL-UNNAMED -Dnet.bytebuddy.experimental=true</argLine>
         </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
+        <version>${maven-surefire-plugin.version}</version>
         <executions>
           <execution>
             <goals>
@@ -253,6 +296,9 @@
             </configuration>
           </execution>
         </executions>
+        <configuration>
+          <argLine>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --add-opens java.base/jdk.internal.reflect=ALL-UNNAMED -Dnet.bytebuddy.experimental=true</argLine>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.jacoco</groupId>
@@ -292,9 +338,9 @@
         <version>4.3.0</version>
         <dependencies>
           <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>4.0.5</version>
           </dependency>
         </dependencies>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -31,16 +31,6 @@
     </developerConnection>
     <tag>HEAD</tag>
   </scm>
-  <distributionManagement>
-    <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-    <repository>
-      <id>ossrh</id>
-      <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
-  </distributionManagement>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -64,6 +54,9 @@
     <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
     <maven-surefire-plugin.version>3.5.4</maven-surefire-plugin.version>
     <spring-boot-maven-plugin.version>4.0.7</spring-boot-maven-plugin.version>
+    <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
+    <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
+    <central-publishing-maven-plugin.version>0.9.0</central-publishing-maven-plugin.version>
   </properties>
   <pluginRepositories>
     <pluginRepository>
@@ -263,8 +256,6 @@
         <artifactId>maven-release-plugin</artifactId>
         <version>2.5.3</version>
         <configuration>
-          <stagingRepository>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2
-          </stagingRepository>
           <tagNameFormat>github_crawler_@{project.version}</tagNameFormat>
           <localCheckout>true</localCheckout>
           <autoVersionSubmodules>true</autoVersionSubmodules>
@@ -357,22 +348,6 @@
           </dependency>
         </dependencies>
       </plugin>
-      <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.8</version>
-        <extensions>true</extensions>
-        <configuration>
-          <serverId>ossrh</serverId>
-          <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-          <autoReleaseAfterClose>true</autoReleaseAfterClose>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.8.2</version>
-      </plugin>
     </plugins>
   </build>
   <profiles>
@@ -401,7 +376,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
-            <version>3.0.1</version>
+            <version>${maven-source-plugin.version}</version>
             <executions>
               <execution>
                 <id>attach-sources</id>
@@ -428,7 +403,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.0.1</version>
+            <version>${maven-gpg-plugin.version}</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -438,6 +413,25 @@
                 </goals>
               </execution>
             </executions>
+            <configuration>
+              <gpgArguments>
+                <arg>--pinentry-mode</arg>
+                <arg>loopback</arg>
+              </gpgArguments>
+            </configuration>
+          </plugin>
+
+          <!-- ✨ NEW Sonatype Central Publishing Plugin -->
+          <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>${central-publishing-maven-plugin.version}</version>
+            <extensions>true</extensions>
+            <configuration>
+              <publishingServerId>central</publishingServerId>
+              <autoPublish>true</autoPublish>
+              <waitUntil>published</waitUntil>
+            </configuration>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
## Context

<!-- Why is this change required? What problem does it solve? -->
This pull request upgrades the project to use Java 25 and updates related configurations, dependencies, and test code to ensure compatibility. It also modernizes test implementations by updating Awaitility usage and cleans up dependency management in the Maven configuration.

**Java version upgrade and configuration:**
* Updated Java version to 25 in GitHub Actions workflows (`build_workflow.yml`, `release_workflow.yml`), `.sdkmanrc`, and added a JVM config flag to allow sun.misc unsafe memory access (`.mvn/jvm.config`). 
**Dependency and Maven configuration updates:**
* Updated the parent POM version to `3.0.0-SNAPSHOT` and modernized/cleaned up dependencies in `github-crawler-autoconfigure/pom.xml`, including switching to `spring-boot-starter-restclient`, updating test dependencies, and removing redundant version tags.

**Test code modernization and Awaitility usage:**
* Replaced deprecated Awaitility usage with the new `untilAsserted` pattern and updated imports in integration tests, improving reliability and readability. 

**Minor code style improvements:**
* Updated usages of `list.get(0)` to `list.getFirst()` for clarity and modern Java compatibility in test assertions. 

These changes ensure the project is ready for Java 25 and improve the maintainability and reliability of the test suite.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I've added tests for my code.
- [x] Documentation has been updated accordingly to this PR
